### PR TITLE
Add base directories and API entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # CivicAI
 CivicAI is a self-hosted AI chatbot that answers local government questions—like trash pickup, permits, or municipal codes—using public city data. Easily customizable for any U.S. city with local or cloud LLMs, vector search, and a simple web UI.
+
+## Components
+
+### API
+The `api/` directory contains the backend API server. Start developing by editing `api/app.py` and extending the endpoints as needed.
+
+### Web
+The `web/` directory is intended for the front-end web application.
+
+### Data
+The `data/` directory holds sample datasets or data-loading scripts.

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,1 @@
+# API\n\nPlaceholder for API server code.

--- a/api/app.py
+++ b/api/app.py
@@ -1,0 +1,20 @@
+from http.server import BaseHTTPRequestHandler, HTTPServer
+
+
+class SimpleHandler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        self.send_response(200)
+        self.send_header('Content-type', 'text/plain')
+        self.end_headers()
+        self.wfile.write(b"Hello from CivicAI API!")
+
+
+def run(server_class=HTTPServer, handler_class=SimpleHandler):
+    server_address = ('0.0.0.0', 8000)
+    httpd = server_class(server_address, handler_class)
+    print("Starting server on port 8000...")
+    httpd.serve_forever()
+
+
+if __name__ == '__main__':
+    run()

--- a/data/README.md
+++ b/data/README.md
@@ -1,0 +1,1 @@
+# Data\n\nPlaceholder for sample datasets.

--- a/web/README.md
+++ b/web/README.md
@@ -1,0 +1,1 @@
+# Web\n\nPlaceholder for web front-end.


### PR DESCRIPTION
## Summary
- scaffold `api/`, `web/`, and `data/` directories
- add a minimal `api/app.py` server using Python's `http.server`
- document components in the main README
- add placeholder READMEs for each new component

## Testing
- `python3 -m py_compile api/app.py`


------
https://chatgpt.com/codex/tasks/task_e_685c7b76b8e4833298af603eb214e725