### PR TITLE
Add system prompt and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,5 @@
 # CivicAI
 CivicAI is a self-hosted AI chatbot that answers local government questions—like trash pickup, permits, or municipal codes—using public city data. Easily customizable for any U.S. city with local or cloud LLMs, vector search, and a simple web UI.
+
+## Customizing for your city
+The chatbot prompt lives in `prompts/system_prompt.txt`. Edit that file to reference your city's specific regulations, services, and website links. Restart the application after updating the prompt so the changes take effect.

--- a/prompts/system_prompt.txt
+++ b/prompts/system_prompt.txt
@@ -1,0 +1,1 @@
+You are a city service chatbot for the City of Exampleton. Answer questions using the city's public data, municipal code, and service schedules. When you reference ordinances or regulations, cite the relevant code section or policy name. Include links to official city websites if available. Be concise and do not answer outside the scope of city government questions.


### PR DESCRIPTION
## Summary
- add a default prompt for the chatbot under `prompts/system_prompt.txt`
- explain how to adjust the prompt for other cities in the README

## Testing
- `git show --stat`

------
https://chatgpt.com/codex/tasks/task_e_685c7b77001c8332aeada87638fb1ca0