### PR TITLE
Add FastAPI chat endpoint

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -1,20 +1,20 @@
-from http.server import BaseHTTPRequestHandler, HTTPServer
+from fastapi import FastAPI
+from pydantic import BaseModel
 
+app = FastAPI()
 
-class SimpleHandler(BaseHTTPRequestHandler):
-    def do_GET(self):
-        self.send_response(200)
-        self.send_header('Content-type', 'text/plain')
-        self.end_headers()
-        self.wfile.write(b"Hello from CivicAI API!")
+class ChatRequest(BaseModel):
+    message: str
 
+class ChatResponse(BaseModel):
+    response: str
 
-def run(server_class=HTTPServer, handler_class=SimpleHandler):
-    server_address = ('0.0.0.0', 8000)
-    httpd = server_class(server_address, handler_class)
-    print("Starting server on port 8000...")
-    httpd.serve_forever()
+@app.post("/chat", response_model=ChatResponse)
+async def chat(req: ChatRequest):
+    """Handle chat messages and return a placeholder response."""
+    placeholder = f"You said: {req.message}. This is a placeholder response."
+    return {"response": placeholder}
 
-
-if __name__ == '__main__':
-    run()
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- replace the simple HTTP server with a FastAPI application
- add `/chat` endpoint returning a placeholder message

## Testing
- `python -m py_compile api/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c8c4c989483329051a269fde76731