### PR TITLE
Add simple chat UI

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -1,1 +1,14 @@
-# Web\n\nPlaceholder for web front-end.
+# Web
+
+This directory contains a simple single-page chat interface.
+
+## Launching the UI
+
+Any static file server can host the page. The simplest option is Python's built-in `http.server` module:
+
+```bash
+cd web
+python3 -m http.server 8080
+```
+
+Then open [http://localhost:8080](http://localhost:8080) in your browser and interact with the chat.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CivicAI Chat</title>
+    <style>
+        body { font-family: Arial, sans-serif; margin: 0; padding: 0; }
+        #chat { height: 80vh; overflow-y: auto; padding: 1em; border-bottom: 1px solid #ccc; }
+        .msg { margin: 0.5em 0; }
+        #inputForm { display: flex; padding: 1em; }
+        #inputForm input[type=text] { flex-grow: 1; padding: 0.5em; font-size: 1em; }
+        #inputForm button { padding: 0.5em 1em; margin-left: 0.5em; }
+    </style>
+</head>
+<body>
+    <div id="chat"></div>
+    <form id="inputForm">
+        <input type="text" id="message" placeholder="Type your message..." autocomplete="off" required>
+        <button type="submit">Send</button>
+    </form>
+
+    <script>
+        const chat = document.getElementById('chat');
+        const form = document.getElementById('inputForm');
+        const input = document.getElementById('message');
+
+        function appendMessage(text, sender) {
+            const div = document.createElement('div');
+            div.className = 'msg';
+            div.textContent = sender + ': ' + text;
+            chat.appendChild(div);
+            chat.scrollTop = chat.scrollHeight;
+        }
+
+        form.addEventListener('submit', e => {
+            e.preventDefault();
+            const text = input.value.trim();
+            if (!text) return;
+            appendMessage(text, 'You');
+            input.value = '';
+            // Placeholder for bot response
+            setTimeout(() => appendMessage('This is a placeholder response.', 'Bot'), 500);
+        });
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `web/index.html` with a minimal chat interface
- document how to start a static server for the web frontend

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685c8c4e86d08332b783dd2c27a1c57c