### PR TITLE
Add chat endpoint tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ The `web/` directory is intended for the front-end web application.
 
 ### Data
 The `data/` directory holds sample datasets or data-loading scripts.
+
+## Running Tests
+
+Run `pytest` from the repository root to execute the test suite:
+
+```bash
+pytest
+```
+
+This will start a temporary API server and verify that the `/chat` endpoint
+responds with JSON.

--- a/api/app.py
+++ b/api/app.py
@@ -3,16 +3,24 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 
 class SimpleHandler(BaseHTTPRequestHandler):
     def do_GET(self):
-        self.send_response(200)
-        self.send_header('Content-type', 'text/plain')
-        self.end_headers()
-        self.wfile.write(b"Hello from CivicAI API!")
+        if self.path == "/chat":
+            self.send_response(200)
+            self.send_header("Content-type", "application/json")
+            self.end_headers()
+            self.wfile.write(b'{"message": "Hello from CivicAI chat"}')
+        elif self.path == "/":
+            self.send_response(200)
+            self.send_header('Content-type', 'text/plain')
+            self.end_headers()
+            self.wfile.write(b"Hello from CivicAI API!")
+        else:
+            self.send_error(404)
 
 
-def run(server_class=HTTPServer, handler_class=SimpleHandler):
-    server_address = ('0.0.0.0', 8000)
+def run(server_class=HTTPServer, handler_class=SimpleHandler, host='0.0.0.0', port=8000):
+    server_address = (host, port)
     httpd = server_class(server_address, handler_class)
-    print("Starting server on port 8000...")
+    print(f"Starting server on port {port}...")
     httpd.serve_forever()
 
 

--- a/tests/test_chat_endpoint.py
+++ b/tests/test_chat_endpoint.py
@@ -1,0 +1,41 @@
+import json
+import threading
+import http.client
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+from api.app import SimpleHandler, HTTPServer
+
+
+def start_server():
+    httpd = HTTPServer(('localhost', 0), SimpleHandler)
+    thread = threading.Thread(target=httpd.serve_forever)
+    thread.daemon = True
+    thread.start()
+    return httpd
+
+
+def stop_server(httpd):
+    httpd.shutdown()
+    httpd.server_close()
+
+
+def test_chat_returns_json():
+    httpd = start_server()
+    port = httpd.server_address[1]
+
+    conn = http.client.HTTPConnection('localhost', port)
+    conn.request('GET', '/chat')
+    resp = conn.getresponse()
+    body = resp.read()
+
+    assert resp.status == 200
+    assert resp.getheader('Content-Type') == 'application/json'
+    # Ensure response body is valid JSON
+    data = json.loads(body.decode())
+    assert 'message' in data
+
+    conn.close()
+    stop_server(httpd)


### PR DESCRIPTION
## Summary
- add `/chat` endpoint to API
- create unit test to verify JSON response
- document how to run tests in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8c5001808332a572b801306daf4a