### PR TITLE
Add ingestion pipeline and LLM-backed API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+
+.venv/
+venv/
+env/
+
+vector_db/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -11,6 +11,14 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
    ```
 5. Visit `http://localhost:8000` to verify the server is running.
 
+### Ingesting city data
+Sample Santa Barbara documents are provided in `data/santa_barbara/`. Run the
+ingestion script to create a local Chroma database before starting the API:
+
+```bash
+python data/ingest.py
+```
+
 ## Folder overview
 - **`api/`** \u2013 backend API server written in Python.
 - **`web/`** \u2013 front-end web application placeholder.
@@ -18,4 +26,7 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 
 ## Development
 Edit `api/app.py` to add endpoints or change logic. The server automatically reloads when you restart the command above. Front-end and data-related code live under `web/` and `data/` respectively.
+
+The included web interface (`web/index.html`) sends messages to the FastAPI
+server at `http://localhost:8000/chat`.
 

--- a/api/README.md
+++ b/api/README.md
@@ -1,1 +1,10 @@
-# API\n\nPlaceholder for API server code.
+# API
+
+The FastAPI server exposes a `/chat` endpoint that generates answers using a
+local or remote LLM. Before running the server, ingest city documents so the
+vector database can provide context:
+
+```bash
+python ../data/ingest.py
+python app.py
+```

--- a/data/README.md
+++ b/data/README.md
@@ -1,1 +1,6 @@
-# Data\n\nPlaceholder for sample datasets.
+# Data
+
+This directory contains example documents for Santa Barbara along with an
+`ingest.py` script that loads them into a local Chroma database.
+
+Run `python ingest.py` to create the vector store used by the API.

--- a/data/ingest.py
+++ b/data/ingest.py
@@ -1,0 +1,44 @@
+"""Ingest Santa Barbara documents into a local Chroma vector store."""
+
+from pathlib import Path
+
+from langchain.text_splitter import RecursiveCharacterTextSplitter
+from langchain.vectorstores import Chroma
+from langchain.embeddings import OpenAIEmbeddings, HuggingFaceEmbeddings
+
+
+DATA_DIR = Path(__file__).parent / "santa_barbara"
+DB_DIR = Path(__file__).parent.parent / "vector_db"
+
+
+def load_documents() -> list[str]:
+    texts = []
+    for path in DATA_DIR.glob("*.txt"):
+        texts.append(path.read_text())
+    return texts
+
+
+def get_embeddings():
+    try:
+        return OpenAIEmbeddings(model="text-embedding-3-small")
+    except Exception:
+        return HuggingFaceEmbeddings(model_name="BAAI/bge-small-en")
+
+
+def main():
+    documents = load_documents()
+    splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
+    chunks = []
+    for doc in documents:
+        chunks.extend(splitter.split_text(doc))
+
+    embeddings = get_embeddings()
+    vectordb = Chroma(persist_directory=str(DB_DIR), embedding_function=embeddings)
+    ids = [str(i) for i in range(len(chunks))]
+    vectordb.add_texts(chunks, ids=ids)
+    vectordb.persist()
+    print(f"Ingested {len(chunks)} chunks into {DB_DIR}")
+
+
+if __name__ == "__main__":
+    main()

--- a/data/santa_barbara/city_council.txt
+++ b/data/santa_barbara/city_council.txt
@@ -1,0 +1,1 @@
+Santa Barbara City Council consists of a mayor elected at-large and six council members elected by district. Contact information for each member is available on the city's website.

--- a/data/santa_barbara/permits.txt
+++ b/data/santa_barbara/permits.txt
@@ -1,0 +1,1 @@
+Fence permits are required for walls or fences over 3.5 feet in the front yard or over 8 feet anywhere on the property. Remodeling projects often need building permits. Event permits are handled by the city Parks & Recreation department.

--- a/data/santa_barbara/trash_faq.txt
+++ b/data/santa_barbara/trash_faq.txt
@@ -1,0 +1,5 @@
+Q: When is trash pickup in Santa Barbara?
+A: Residential trash pickup is weekly on assigned days depending on your neighborhood. Bins must be placed at the curb by 6 a.m. on your collection day.
+
+Q: Who do I call about missed pickups?
+A: Contact MarBorg Industries at 805-963-1852 for any issues with missed trash, recycling, or green waste service.

--- a/data/santa_barbara/zoning_excerpt.txt
+++ b/data/santa_barbara/zoning_excerpt.txt
@@ -1,0 +1,1 @@
+The Santa Barbara Municipal Code Title 28 covers zoning regulations. The R-1 single family zone allows one dwelling unit per lot with a maximum height of 30 feet.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,6 @@
+fastapi
+uvicorn
+langchain
+chromadb
+openai
+ollama

--- a/web/README.md
+++ b/web/README.md
@@ -12,3 +12,6 @@ python3 -m http.server 8080
 ```
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser and interact with the chat.
+
+Messages are sent to the API server running on `http://localhost:8000/chat`, so
+ensure the FastAPI server is active.

--- a/web/index.html
+++ b/web/index.html
@@ -39,8 +39,14 @@
             if (!text) return;
             appendMessage(text, 'You');
             input.value = '';
-            // Placeholder for bot response
-            setTimeout(() => appendMessage('This is a placeholder response.', 'Bot'), 500);
+            fetch('http://localhost:8000/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: text })
+            })
+            .then(r => r.json())
+            .then(data => appendMessage(data.response, 'Bot'))
+            .catch(err => appendMessage('Error: ' + err, 'Bot'));
         });
     </script>
 </body>


### PR DESCRIPTION
## Summary
- enable cross-origin requests and add simple LLM integration
- add ingestion script for Santa Barbara documents using LangChain/Chroma
- store sample Santa Barbara data
- update web UI to call the `/chat` endpoint
- document running the ingester and API
- add basic requirements and `.gitignore`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685c8ec2b7508332a33f9c866d8cdeb4