### PR TITLE
Add dependency setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -e
+
+# Upgrade pip
+python -m pip install --upgrade pip
+
+# If a local wheels directory exists, install from there
+if [ -d "wheels" ]; then
+    python -m pip install --no-index --find-links wheels -r requirements.txt
+else
+    python -m pip install -r requirements.txt
+fi


### PR DESCRIPTION
## Summary
- add `setup.sh` for installing dependencies

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c8ec818288332a109c3e2298de456