### PR TITLE
Add wheels directory and update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 1. Ensure Python 3.8 or newer is installed.
 2. Clone this repository and change into its directory.
 3. (Optional) Create a virtual environment: `python -m venv .venv && source .venv/bin/activate`.
-4. Start the API server:
+4. Run `./setup.sh` to install dependencies from the `wheels/` directory.
+   The wheel files must be built or downloaded on a machine with internet access
+   and copied into `wheels/` before running this script.
+5. Start the API server:
    ```bash
    python api/app.py
    ```
-5. Visit `http://localhost:8000` to verify the server is running.
+6. Visit `http://localhost:8000` to verify the server is running.
 
 ### Ingesting city data
 Sample Santa Barbara documents are provided in `data/santa_barbara/`. Run the

--- a/wheels/README.md
+++ b/wheels/README.md
@@ -1,0 +1,1 @@
+Wheel files built from requirements.txt should be placed in this directory.


### PR DESCRIPTION
## Summary
- add `wheels/` directory for dependency wheels
- update README to mention running `./setup.sh` before other commands
- explain that wheel files need to be built or downloaded on a machine with internet access

## Testing
- `python -m pip wheel -r requirements.txt -w wheels` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_685c9c78503c83329572dd51d1b7a54c