### PR TITLE
Support local embeddings model

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,12 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 5. Visit `http://localhost:8000` to verify the server is running.
 
 ### Ingesting city data
-Sample Santa Barbara documents are provided in `data/santa_barbara/`. Run the
-ingestion script to create a local Chroma database before starting the API:
+Sample Santa Barbara documents are provided in `data/santa_barbara/`. The
+ingestion script requires the `BAAI/bge-small-en` embeddings model. Download
+the model from [Hugging Face](https://huggingface.co/BAAI/bge-small-en) and
+place the files under `models/bge-small-en/` so they are available offline.
+Then run the ingestion script to create a local Chroma database before starting
+the API:
 
 ```bash
 python data/ingest.py

--- a/api/app.py
+++ b/api/app.py
@@ -1,6 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
+from pathlib import Path
 
 app = FastAPI()
 
@@ -36,7 +37,11 @@ if OpenAIEmbeddings or HuggingFaceEmbeddings:
         embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
     except Exception:
         try:
-            embeddings = HuggingFaceEmbeddings(model_name="BAAI/bge-small-en")
+            model_dir = Path(__file__).parent.parent / "models" / "bge-small-en"
+            if model_dir.exists():
+                embeddings = HuggingFaceEmbeddings(model_name=str(model_dir))
+            else:
+                embeddings = HuggingFaceEmbeddings(model_name="BAAI/bge-small-en")
         except Exception:
             embeddings = None
 

--- a/data/README.md
+++ b/data/README.md
@@ -4,3 +4,11 @@ This directory contains example documents for Santa Barbara along with an
 `ingest.py` script that loads them into a local Chroma database.
 
 Run `python ingest.py` to create the vector store used by the API.
+
+## Preloading the embedding model
+
+`ingest.py` falls back to the `BAAI/bge-small-en` model when OpenAI
+embeddings are unavailable. Download the model files from
+[Hugging Face](https://huggingface.co/BAAI/bge-small-en) and place them in
+`models/bge-small-en/` at the repository root if you want to avoid network
+downloads during ingestion or API startup.

--- a/data/ingest.py
+++ b/data/ingest.py
@@ -22,6 +22,9 @@ def get_embeddings():
     try:
         return OpenAIEmbeddings(model="text-embedding-3-small")
     except Exception:
+        model_dir = Path(__file__).parent.parent / "models" / "bge-small-en"
+        if model_dir.exists():
+            return HuggingFaceEmbeddings(model_name=str(model_dir))
         return HuggingFaceEmbeddings(model_name="BAAI/bge-small-en")
 
 


### PR DESCRIPTION
## Summary
- document pre-downloading of embedding model
- load embeddings from local directory when available

## Testing
- `python -m py_compile data/ingest.py api/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685c9c7a317c8332b79fe17940828ed4