### PR TITLE
Fix ASGI entrypoint for replit

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
    and copied into `wheels/` before running this script.
 5. Start the API server:
    ```bash
-   python api/app.py
+   uvicorn main:app --host 0.0.0.0 --port 8000
    ```
 6. Visit `http://localhost:8000` to verify the server is running.
 

--- a/api/README.md
+++ b/api/README.md
@@ -6,5 +6,5 @@ vector database can provide context:
 
 ```bash
 python ../data/ingest.py
-python app.py
+uvicorn main:app --host 0.0.0.0 --port 8000
 ```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,1 @@
+from api.app import app


### PR DESCRIPTION
## Summary
- add a simple `main.py` to expose `app`
- document starting with `uvicorn main:app`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685cdc764130833288e6fda9cfb25034