### PR TITLE
Add Replit run configuration

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,1 @@
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -5,23 +5,14 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 1. Ensure Python 3.8 or newer is installed.
 2. Clone this repository and change into its directory.
 3. (Optional) Create a virtual environment: `python -m venv .venv && source .venv/bin/activate`.
-ffs0qa-codex/update-readme-with-setup-instructions
 4. Install dependencies using `./setup.sh`. When no internet connection is available the script installs from a prepopulated `wheels/` directory.
-=======
-4. Run `./setup.sh` to install dependencies from the `wheels/` directory.
-   The wheel files must be built or downloaded on a machine with internet access
-   and copied into `wheels/` before running this script.
-main
 5. Start the API server:
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8000
    ```
 6. Visit `http://localhost:8000` to verify the server is running.
-ffs0qa-codex/update-readme-with-setup-instructions
 
 **Workflow:** run `./setup.sh`, then `python data/ingest.py`, and finally `python api/app.py`.
-=======
- main
 
 ### Ingesting city data
 Sample Santa Barbara documents are provided in `data/santa_barbara/`. The

--- a/main.py
+++ b/main.py
@@ -1,1 +1,9 @@
+"""Entry point for running the FastAPI server on platforms like Replit."""
+
 from api.app import app
+
+
+if __name__ == "__main__":
+    import uvicorn
+
+    uvicorn.run(app, host="0.0.0.0", port=8000)


### PR DESCRIPTION
## Summary
- add `.replit` to define the default run command
- update `main.py` so executing it starts the FastAPI server

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_685ce6b80de483328ab4521619ca52fe