### PR TITLE
Switch docs to python3

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,1 +1,1 @@
-run = "python main.py"
+run = "python3 main.py"

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 ## Setup
 1. Ensure Python 3.8 or newer is installed.
 2. Clone this repository and change into its directory.
-3. (Optional) Create a virtual environment: `python -m venv .venv && source .venv/bin/activate`.
+3. (Optional) Create a virtual environment: `python3 -m venv .venv && source .venv/bin/activate`.
 4. Install dependencies using `./setup.sh`. When no internet connection is available the script installs from a prepopulated `wheels/` directory.
 5. Start the API server:
    ```bash
@@ -12,7 +12,7 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
    ```
 6. Visit `http://localhost:8000` to verify the server is running.
 
-**Workflow:** run `./setup.sh`, then `python data/ingest.py`, and finally `python api/app.py`.
+**Workflow:** run `./setup.sh`, then `python3 data/ingest.py`, and finally `python3 api/app.py`.
 
 ### Ingesting city data
 Sample Santa Barbara documents are provided in `data/santa_barbara/`. The
@@ -23,7 +23,7 @@ Then run the ingestion script to create a local Chroma database before starting
 the API:
 
 ```bash
-python data/ingest.py
+python3 data/ingest.py
 ```
 
 ## Folder overview

--- a/api/README.md
+++ b/api/README.md
@@ -5,6 +5,6 @@ local or remote LLM. Before running the server, ingest city documents so the
 vector database can provide context:
 
 ```bash
-python ../data/ingest.py
+python3 ../data/ingest.py
 uvicorn main:app --host 0.0.0.0 --port 8000
 ```

--- a/data/README.md
+++ b/data/README.md
@@ -3,7 +3,7 @@
 This directory contains example documents for Santa Barbara along with an
 `ingest.py` script that loads them into a local Chroma database.
 
-Run `python ingest.py` to create the vector store used by the API.
+Run `python3 ingest.py` to create the vector store used by the API.
 
 ## Preloading the embedding model
 

--- a/setup.sh
+++ b/setup.sh
@@ -2,11 +2,11 @@
 set -e
 
 # Upgrade pip
-python -m pip install --upgrade pip
+python3 -m pip install --upgrade pip
 
 # If a local wheels directory exists, install from there
 if [ -d "wheels" ]; then
-    python -m pip install --no-index --find-links wheels -r requirements.txt
+    python3 -m pip install --no-index --find-links wheels -r requirements.txt
 else
-    python -m pip install -r requirements.txt
+    python3 -m pip install -r requirements.txt
 fi


### PR DESCRIPTION
## Summary
- replace `python` with `python3` in documentation
- update `.replit` to use python3
- run `python3 -m pip` in `setup.sh`

## Testing
- `python3 -m py_compile main.py api/app.py data/ingest.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cee19c0b08332a4253f3c8b2ff8f1