### PR TITLE
Fix pip for local setup

### DIFF
--- a/replit.nix
+++ b/replit.nix
@@ -1,5 +1,5 @@
 { pkgs }: {
   deps = [
- pkgs.python3
+ pkgs.python3Full
   ];
 }

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,7 @@
 set -e
 
 # Upgrade pip
+python3 -m ensurepip --upgrade
 python3 -m pip install --upgrade pip
 
 # If a local wheels directory exists, install from there


### PR DESCRIPTION
## Summary
- include pip via `python3Full`
- ensure pip is bootstrapped in `setup.sh`

## Testing
- `bash setup.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*


------
https://chatgpt.com/codex/tasks/task_e_685d0091224c83328eb07bece4e50af0