### PR TITLE
Fix duplicate requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,4 +4,3 @@ langchain
 chromadb
 openai
 ollama
-fastapi


### PR DESCRIPTION
## Summary
- remove duplicate entry from requirements.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d71864b3883329048abc8a0f62ebe