### PR TITLE
Add Replit Nix config

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,13 @@ API. Without it, the server falls back to local models when available or returns
 
 Run `pytest` to execute the small test suite.
 
+### Running on Replit
+
+This repository includes a simple `replit.nix` file so that a Python
+interpreter is available by default when opened on Replit. The Nix
+configuration installs `python3` and `pip`, letting you run the
+application without manual setup. After the environment loads, execute
+`./setup.sh` to install all Python dependencies. When the `wheels/`
+directory is present the script installs from those prebuilt wheels so a
+network connection is unnecessary.
+

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,7 @@
+{ pkgs }:
+{
+  deps = [
+    pkgs.python3
+    pkgs.python3Packages.pip
+  ];
+}


### PR DESCRIPTION
## Summary
- provide a minimal `replit.nix` with Python and pip
- document how to use Replit and note offline installs with `setup.sh`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d78ad48408332af9855291f47f6e6