### PR TITLE
Add python check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,6 +1,12 @@
 #!/usr/bin/env bash
 set -e
 
+# Ensure Python 3 is installed
+if ! command -v python3 >/dev/null && ! command -v python >/dev/null; then
+    echo "Error: Python 3 is required but was not found." >&2
+    exit 1
+fi
+
 # Upgrade pip
 python3 -m ensurepip --upgrade
 python3 -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- add Python 3 existence check at start of `setup.sh`

## Testing
- `pytest -q` *(fails: `ModuleNotFoundError: No module named 'fastapi'`)*
- `./setup.sh` *(fails to install packages due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685d78afa4908332b30d867d74b0fee6