### PR TITLE
Improve Python detection

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,1 +1,1 @@
-run = "python3 main.py"
+run = "python main.py"

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 
 ## Setup
 1. Ensure Python 3.8 or newer is installed.
+   Your system may use the `python` command instead of `python3`; adjust the commands below accordingly.
 2. Clone this repository and change into its directory.
-3. (Optional) Create a virtual environment: `python3 -m venv .venv && source .venv/bin/activate`.
+3. (Optional) Create a virtual environment: `python3 -m venv .venv && source .venv/bin/activate` (use `python -m venv` if `python3` isn't available).
 4. Install dependencies using `./setup.sh`. When no internet connection is available the script installs from a prepopulated `wheels/` directory.
 5. Start the API server:
    ```bash
@@ -12,7 +13,7 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
    ```
 6. Visit `http://localhost:8000` to verify the server is running.
 
-**Workflow:** run `./setup.sh`, then `python3 data/ingest.py`, and finally `python3 api/app.py`.
+**Workflow:** run `./setup.sh`, then `python3 data/ingest.py` (or `python data/ingest.py`), and finally `python3 api/app.py` (or `python api/app.py`).
 
 ### Ingesting city data
 Sample Santa Barbara documents are provided in `data/santa_barbara/`. The
@@ -23,7 +24,7 @@ Then run the ingestion script to create a local Chroma database before starting
 the API:
 
 ```bash
-python3 data/ingest.py
+python3 data/ingest.py  # or `python data/ingest.py`
 ```
 
 ## Folder overview

--- a/api/README.md
+++ b/api/README.md
@@ -5,7 +5,7 @@ database. Before running the server, ingest city documents so the vector
 database can provide context:
 
 ```bash
-python3 ../data/ingest.py
+python3 ../data/ingest.py  # or `python ../data/ingest.py`
 uvicorn main:app --host 0.0.0.0 --port 8000
 ```
 

--- a/data/README.md
+++ b/data/README.md
@@ -3,7 +3,7 @@
 This directory contains example documents for Santa Barbara along with an
 `ingest.py` script that loads them into a local Chroma database.
 
-Run `python3 ingest.py` to create the vector store used by the API.
+Run `python3 ingest.py` (or `python ingest.py`) to create the vector store used by the API.
 
 ## Preloading the embedding model
 

--- a/setup.sh
+++ b/setup.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 set -e
 
+# Detect python3 or python
+PY_CMD=$(command -v python3 || command -v python)
+if [ -z "$PY_CMD" ]; then
+    echo "Python 3 is required." >&2
+    exit 1
+fi
+
 # Upgrade pip
-python3 -m ensurepip --upgrade
-python3 -m pip install --upgrade pip
+$PY_CMD -m ensurepip --upgrade
+$PY_CMD -m pip install --upgrade pip
 
 # If a local wheels directory exists, install from there
 if [ -d "wheels" ]; then
-    python3 -m pip install --no-index --find-links wheels -r requirements.txt
+    $PY_CMD -m pip install --no-index --find-links wheels -r requirements.txt
 else
-    python3 -m pip install -r requirements.txt
+    $PY_CMD -m pip install -r requirements.txt
 fi

--- a/web/README.md
+++ b/web/README.md
@@ -10,7 +10,7 @@ Any static file server can host the page. The simplest option is Python's built-
 
 ```bash
 cd web
-python3 -m http.server 8080
+python3 -m http.server 8080  # or `python -m http.server`
 ```
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser and interact with the chat.


### PR DESCRIPTION
## Summary
- detect `python3` or `python` automatically in `setup.sh`
- allow using `python` or `python3` in docs
- update `.replit` to run with `python`

## Testing
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d789fa434833283509d07d41c223c