### PR TITLE
Pin openai version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ fastapi
 uvicorn
 langchain
 chromadb
-openai
+openai>=0.27,<1
 ollama


### PR DESCRIPTION
## Summary
- pin `openai` dependency in `requirements.txt`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d7e579f788332af73baad828828f2