### PR TITLE
Update README to require virtual environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 1. Ensure Python 3.8 or newer is installed.
    Your system may use the `python` command instead of `python3`; adjust the commands below accordingly.
 2. Clone this repository and change into its directory.
-3. (Optional) Create a virtual environment: `python3 -m venv .venv && source .venv/bin/activate` (use `python -m venv` if `python3` isn't available).
+3. **Create and activate a virtual environment** before installing dependencies:
+   `python3 -m venv .venv && source .venv/bin/activate` (use `python -m venv` if `python3` isn't available).
 4. Install dependencies using `./setup.sh`. When no internet connection is available the script installs from a prepopulated `wheels/` directory. This script also installs `pip` when it's missing.
 5. If you see `ModuleNotFoundError` errors (e.g., for FastAPI) or `pip` isn't found, rerun `./setup.sh` to ensure all dependencies are installed.
 6. Start the API server:


### PR DESCRIPTION
## Summary
- update setup instructions to make creating a virtual environment mandatory

## Testing
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d7e56db9c833291e04c25083c71c9