### PR TITLE
Add start script and auto install in main

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
    ```
 7. Visit `http://localhost:8000` to verify the server is running.
 
+Alternatively, execute `./start.sh` to perform steps 3–7 automatically.
+
 **Workflow:** run `./setup.sh`, then `python3 data/ingest.py` (or `python data/ingest.py`), and finally `python3 api/app.py` (or `python api/app.py`).
 
 ### Using Ollama with OpenHermes

--- a/main.py
+++ b/main.py
@@ -4,10 +4,24 @@ try:
     from api.app import app
 except ModuleNotFoundError as exc:  # pragma: no cover - triggers only when deps missing
     if exc.name == "fastapi":
-        raise SystemExit(
-            "FastAPI is not installed. Run './setup.sh' to install all dependencies."
-        ) from exc
-    raise
+        import subprocess
+        from pathlib import Path
+
+        script = Path(__file__).with_name("setup.sh")
+        if script.exists():
+            try:
+                subprocess.run(["bash", str(script)], check=True)
+                from api.app import app  # retry after installing deps
+            except Exception:
+                raise SystemExit(
+                    "FastAPI is not installed. Run './setup.sh' to install all dependencies."
+                ) from exc
+        else:
+            raise SystemExit(
+                "FastAPI is not installed. Run './setup.sh' to install all dependencies."
+            ) from exc
+    else:
+        raise
 
 
 if __name__ == "__main__":

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+PY_CMD=$(command -v python3 || command -v python)
+if [ -z "$PY_CMD" ]; then
+    echo "Python 3 is required." >&2
+    exit 1
+fi
+
+if [ ! -d ".venv" ]; then
+    "$PY_CMD" -m venv .venv
+fi
+
+# shellcheck disable=SC1091
+source .venv/bin/activate
+
+./setup.sh
+
+.venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000


### PR DESCRIPTION
## Summary
- add script `start.sh` to create a venv, install dependencies and launch the server
- update README with the new quick-start step
- automatically run `setup.sh` from `main.py` when FastAPI isn't installed

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685d82a201d48332861af5eea8d81dee