### PR TITLE
Improve setup.sh to auto-create venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,10 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 1. Ensure Python 3.8 or newer is installed.
    Your system may use the `python` command instead of `python3`; adjust the commands below accordingly.
 2. Clone this repository and change into its directory.
-3. **Create and activate a virtual environment** before installing dependencies:
+3. **(Optional) create and activate a virtual environment** before installing dependencies:
    `python3 -m venv .venv && source .venv/bin/activate` (use `python -m venv` if `python3` isn't available).
-4. Install dependencies using `./setup.sh`. When no internet connection is available the script installs from a prepopulated `wheels/` directory. This script also installs `pip` when it's missing.
+   If no environment is active, `./setup.sh` automatically creates `.venv` and installs packages there.
+4. Install dependencies using `./setup.sh`. When no internet connection is available the script installs from a prepopulated `wheels/` directory. This script also installs `pip` when it's missing and activates `.venv` when necessary.
 5. If you see `ModuleNotFoundError` errors (e.g., for FastAPI) or `pip` isn't found, rerun `./setup.sh` to ensure all dependencies are installed.
 6. Start the API server:
    ```bash

--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,16 @@ if [ -z "$PY_CMD" ]; then
     exit 1
 fi
 
+# Create a virtual environment automatically when none is active
+if [ -z "$VIRTUAL_ENV" ]; then
+    echo "No virtual environment detected. Using .venv for setup." >&2
+    if [ ! -d ".venv" ]; then
+        "$PY_CMD" -m venv .venv
+    fi
+    # shellcheck disable=SC1091
+    source .venv/bin/activate
+fi
+
 # Upgrade pip
 $PY_CMD -m ensurepip --upgrade
 $PY_CMD -m pip install --upgrade pip


### PR DESCRIPTION
## Summary
- make `setup.sh` create/activate `.venv` when no environment is active
- update README to describe automatic venv creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*
- `./setup.sh` *(fails: Could not find a version that satisfies the requirement fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685d899f24b0833295e76ab1e4b726f7