### PR TITLE
Ensure setup script uses venv python

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -16,6 +16,7 @@ if [ -z "$VIRTUAL_ENV" ]; then
     fi
     # shellcheck disable=SC1091
     source .venv/bin/activate
+    PY_CMD=$(command -v python)
 fi
 
 # Upgrade pip


### PR DESCRIPTION
## Summary
- activate `.venv` and update `PY_CMD` to point to the virtual env's Python

## Testing
- `pytest -q` *(fails: fastapi not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685d909795688332bff5f69b43efad72