### PR TITLE
Check wheel availability before offline install

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -25,6 +25,25 @@ $PY_CMD -m pip install --upgrade pip
 
 # If a local wheels directory exists, install from there
 if [ -d "wheels" ]; then
+    # Verify that every requirement has a corresponding wheel file
+    missing=()
+    shopt -s nocaseglob
+    while read -r req; do
+        req=$(echo "$req" | sed 's/#.*//' | xargs)
+        [ -z "$req" ] && continue
+        pkg=$(echo "$req" | cut -d'[' -f1 | cut -d'<' -f1 | cut -d'>' -f1 \
+            | cut -d'=' -f1 | cut -d' ' -f1 | cut -d';' -f1)
+        wheel_pkg=$(echo "$pkg" | tr '[:upper:]' '[:lower:]' | tr '_' '-')
+        if ! compgen -G "wheels/${wheel_pkg}-*.whl" > /dev/null; then
+            missing+=("$pkg")
+        fi
+    done < requirements.txt
+    shopt -u nocaseglob
+    if [ ${#missing[@]} -ne 0 ]; then
+        echo "Missing wheel files for packages: ${missing[*]}" >&2
+        echo "Run: pip download -r requirements.txt -d wheels while online." >&2
+        exit 1
+    fi
     $PY_CMD -m pip install --no-index --find-links wheels -r requirements.txt
 else
     $PY_CMD -m pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- upgrade setup.sh to verify wheels exist before offline install
- abort with instructions if wheels for requirements are missing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685d94a911048332b2ff0be42f1b7635