### PR TITLE
Add dev test dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,13 @@ API. Leaving this variable unset makes the app rely solely on the local
 
 ### Running tests
 
-Run `pytest` to execute the small test suite.
+Install the additional development packages before running the tests:
+
+```bash
+pip install -r requirements-dev.txt
+```
+
+Then execute the suite with `pytest`.
 
 ### Running on Replit
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+fastapi[test]


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` for testing packages
- document how to install dev requirements before running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685da49ab7f88332a7ed5a0f0379e652