### PR TITLE
Pin dependency versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ Alternatively, execute `./start.sh` to perform steps 3–7 automatically.
 
 **Workflow:** run `./setup.sh`, then `python3 data/ingest.py` (or `python data/ingest.py`), and finally `python3 api/app.py` (or `python api/app.py`).
 
+### Why pin versions?
+The `requirements.txt` file lists exact dependency versions so the
+project installs the same packages every time. This keeps the
+environment reproducible and avoids unexpected changes when working
+offline or rebuilding later.
+
 ### Populating `wheels/` for offline setup
 When you do have an internet connection, predownload the project dependencies so
 they're available later without network access:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-fastapi
-uvicorn
-langchain
-chromadb
-openai>=0.27,<1
-ollama
+fastapi==0.111.0
+uvicorn==0.29.0
+langchain==0.1.17
+chromadb==0.4.24
+openai==0.28.1
+ollama==0.1.4


### PR DESCRIPTION
## Summary
- pin versions for all Python packages in `requirements.txt`
- mention version pinning rationale in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685da49bc1588332ba04c4a415827dbe