### PR TITLE
Serve front-end UI from API root

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
    ```bash
    uvicorn main:app --host 0.0.0.0 --port 8000
    ```
-7. Visit `http://localhost:8000/health` to confirm the server is running. `http://localhost:8000` returns `404` because no root page is served; the web interface is under `web/`.
+7. Visit `http://localhost:8000/health` to confirm the server is running. The front-end UI is served automatically at `http://localhost:8000`.
 
 Alternatively, execute `./start.sh` to perform steps 3–7 automatically.
 
@@ -77,7 +77,8 @@ python3 data/ingest.py  # or `python data/ingest.py`
 Edit `api/app.py` to add endpoints or change logic. The server automatically reloads when you restart the command above. Front-end and data-related code live under `web/` and `data/` respectively.
 
 The included web interface (`web/index.html`) sends messages to the FastAPI
-server at `http://localhost:8000/chat`.
+server at `http://localhost:8000/chat`. When the API is running, open
+`http://localhost:8000/` to use the chat UI.
 
 ### API Endpoints
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,8 +1,11 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from pathlib import Path
 import os
+
+WEB_DIR = Path(__file__).parent.parent / "web"
 
 app = FastAPI()
 
@@ -85,6 +88,10 @@ class ChatRequest(BaseModel):
 class ChatResponse(BaseModel):
     response: str
 
+
+@app.get("/", response_class=FileResponse)
+async def index():
+    return FileResponse(WEB_DIR / "index.html")
 
 @app.get("/health")
 async def health() -> dict[str, str]:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -16,6 +16,12 @@ def test_chat_route():
     assert "response" in resp.json()
 
 
+def test_root_serves_ui():
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "CivicAI Chat" in resp.text
+
+
 def test_ingest_endpoint(monkeypatch):
     """POST /ingest returns completed status and calls ingest.main."""
 

--- a/web/README.md
+++ b/web/README.md
@@ -6,7 +6,8 @@ Press the **Send** button or hit **Enter** to submit a message.
 
 ## Launching the UI
 
-Any static file server can host the page. The simplest option is Python's built-in `http.server` module:
+Once the API server is running, open [http://localhost:8000/](http://localhost:8000/) in your browser to chat.
+Any static file server can host the page as well. The simplest option is Python's built-in `http.server` module:
 
 ```bash
 cd web


### PR DESCRIPTION
## Summary
- add `FileResponse` to serve `index.html` from `/`
- test that root path serves the UI
- document the new behavior in README files

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685da9d83db883329e3272595a3d1878