### PR TITLE
Fix chat endpoint url

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ python3 data/ingest.py  # or `python data/ingest.py`
 Edit `api/app.py` to add endpoints or change logic. The server automatically reloads when you restart the command above. Front-end and data-related code live under `web/` and `data/` respectively.
 
 The included web interface (`web/index.html`) sends messages to the FastAPI
-server at `http://localhost:8000/chat`. When the API is running, open
-`http://localhost:8000/` to use the chat UI.
+server via the `/chat` endpoint on the same host. When the API is running,
+open `http://localhost:8000/` to use the chat UI.
 
 ### API Endpoints
 

--- a/web/README.md
+++ b/web/README.md
@@ -16,5 +16,6 @@ python3 -m http.server 8080  # or `python -m http.server`
 
 Then open [http://localhost:8080](http://localhost:8080) in your browser and interact with the chat.
 
-Messages are sent to the API server running on `http://localhost:8000/chat`, so
-ensure the FastAPI server is active.
+Messages are sent to the `/chat` endpoint on the API server. When hosting the
+front end separately, ensure the FastAPI server is reachable and adjust the
+endpoint URL in `index.html` if needed.

--- a/web/index.html
+++ b/web/index.html
@@ -100,7 +100,8 @@
             if (!text) return;
             appendMessage(text, 'You');
             input.value = '';
-            fetch('http://localhost:8000/chat', {
+            // send to the API running on the same host
+            fetch('/chat', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ message: text })


### PR DESCRIPTION
## Summary
- fetch chat responses using a relative URL so the page works from any host
- document the new endpoint usage in READMEs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_685dafbf6fdc8332bf2c8580c94ceac7