### PR TITLE
Add streaming chat and improved UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,19 +77,22 @@ python3 data/ingest.py  # or `python data/ingest.py`
 Edit `api/app.py` to add endpoints or change logic. The server automatically reloads when you restart the command above. Front-end and data-related code live under `web/` and `data/` respectively.
 
 The included web interface (`web/index.html`) sends messages to the FastAPI
-server via the `/chat` endpoint on the same host. When the API is running,
-open `http://localhost:8000/` to use the chat UI.
+server. When the API is running, open `http://localhost:8000/` to use the chat
+UI. Responses stream back to the browser so you see the answer as it is
+generated.
 
 ### API Endpoints
 
 - `GET /health` – simple health check returning `{"status": "ok"}`.
 - `POST /chat` – send a message and receive an LLM response.
+- `POST /chat_stream` – same as `/chat` but streams tokens as they are generated.
 - `POST /ingest` – rebuild the local vector database from documents.
 
 Set the `OPENAI_API_KEY` environment variable if you want to use the OpenAI
 API. Leaving this variable unset makes the app rely solely on the local
 `openhermes` model via `ollama`. Without either model the server returns
-"LLM response unavailable.".
+"LLM response unavailable.". This open source model is downloaded with
+`ollama pull openhermes` and used by default.
 
 ### Running tests
 

--- a/web/index.html
+++ b/web/index.html
@@ -4,117 +4,61 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>CivicAI Chat</title>
-    <style>
-        body {
-            font-family: Helvetica, Arial, sans-serif;
-            background: #f5f5f7;
-            margin: 0;
-            display: flex;
-            justify-content: center;
-            align-items: center;
-            height: 100vh;
-        }
-        #container {
-            display: flex;
-            flex-direction: column;
-            width: 100%;
-            max-width: 600px;
-            height: 90vh;
-            background: #fff;
-            box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-        }
-        header {
-            background: #4a90e2;
-            color: #fff;
-            padding: 1em;
-            text-align: center;
-            font-size: 1.2em;
-        }
-        #chat {
-            flex-grow: 1;
-            overflow-y: auto;
-            padding: 1em;
-            display: flex;
-            flex-direction: column;
-        }
-        .msg {
-            max-width: 80%;
-            padding: 0.6em 1em;
-            border-radius: 15px;
-            margin: 0.5em 0;
-        }
-        .msg.user {
-            background: #e1f5fe;
-            align-self: flex-end;
-        }
-        .msg.bot {
-            background: #e8eaf6;
-            align-self: flex-start;
-        }
-        #inputForm {
-            display: flex;
-            border-top: 1px solid #ddd;
-        }
-        #inputForm input[type=text] {
-            flex-grow: 1;
-            padding: 1em;
-            border: none;
-            font-size: 1em;
-        }
-        #inputForm button {
-            background: #4a90e2;
-            color: #fff;
-            border: none;
-            padding: 1em;
-            cursor: pointer;
-        }
-        #inputForm button:hover {
-            background: #357ab8;
-        }
-    </style>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
-<body>
-    <div id="container">
-        <header>CivicAI Chat</header>
-        <div id="chat"></div>
-        <form id="inputForm">
-            <input type="text" id="message" placeholder="Type your message..." autocomplete="off" required>
-            <button type="submit">Send</button>
-        </form>
-    </div>
-    <script>
-        const chat = document.getElementById('chat');
-        const form = document.getElementById('inputForm');
-        const input = document.getElementById('message');
+<body class="bg-gray-100 h-screen flex items-center justify-center">
+<div class="flex flex-col w-full max-w-xl h-[90vh] bg-white shadow-md">
+    <header class="bg-blue-500 text-white p-4 text-center text-xl font-semibold">CivicAI Chat</header>
+    <div id="chat" class="flex-1 overflow-y-auto p-4 space-y-2"></div>
+    <form id="inputForm" class="flex border-t border-gray-200">
+        <input type="text" id="message" placeholder="Type your message..." autocomplete="off" required class="flex-1 p-3 outline-none" />
+        <button type="submit" class="bg-blue-500 text-white px-4">Send</button>
+    </form>
+</div>
+<script>
+const chat = document.getElementById('chat');
+const form = document.getElementById('inputForm');
+const input = document.getElementById('message');
 
-        function appendMessage(text, sender) {
-            const div = document.createElement('div');
-            div.className = 'msg ' + (sender === 'You' ? 'user' : 'bot');
-            div.textContent = text;
-            chat.appendChild(div);
-            chat.scrollTop = chat.scrollHeight;
+function appendMessage(text, sender) {
+    const div = document.createElement('div');
+    div.className = sender === 'You' ? 'self-end bg-blue-100 rounded-lg p-2 max-w-[80%]' : 'self-start bg-gray-100 rounded-lg p-2 max-w-[80%]';
+    div.textContent = text;
+    div.classList.add('msg');
+    chat.appendChild(div);
+    chat.scrollTop = chat.scrollHeight;
+}
+
+function streamMessage(text) {
+    appendMessage('', 'Bot');
+    const msgDiv = chat.lastChild;
+    fetch('/chat_stream', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: text })
+    }).then(resp => {
+        const reader = resp.body.getReader();
+        const decoder = new TextDecoder();
+        function read() {
+            reader.read().then(({ done, value }) => {
+                if (done) return;
+                msgDiv.textContent += decoder.decode(value);
+                chat.scrollTop = chat.scrollHeight;
+                read();
+            });
         }
+        read();
+    }).catch(err => { msgDiv.textContent = 'Error: ' + err; });
+}
 
-        function sendMessage() {
-            const text = input.value.trim();
-            if (!text) return;
-            appendMessage(text, 'You');
-            input.value = '';
-            // send to the API running on the same host
-            fetch('/chat', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ message: text })
-            })
-            .then(r => r.json())
-            .then(data => appendMessage(data.response, 'Bot'))
-            .catch(err => appendMessage('Error: ' + err, 'Bot'));
-        }
-
-        form.addEventListener('submit', e => {
-            e.preventDefault();
-            sendMessage();
-        });
-    </script>
+form.addEventListener('submit', e => {
+    e.preventDefault();
+    const text = input.value.trim();
+    if (!text) return;
+    appendMessage(text, 'You');
+    input.value = '';
+    streamMessage(text);
+});
+</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- implement streaming endpoints and ChatEngine API
- serve new `chat_stream` endpoint and use it in the UI
- overhaul `web/index.html` with Tailwind for a nicer look
- document streaming behaviour and default open-source model in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685db0ee6f508332b44b9758381c4596