### PR TITLE
Improve chat frontend

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,12 +7,12 @@
     <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
 </head>
 <body class="bg-gray-100 h-screen flex items-center justify-center">
-<div class="flex flex-col w-full max-w-xl h-[90vh] bg-white shadow-md">
-    <header class="bg-blue-500 text-white p-4 text-center text-xl font-semibold">CivicAI Chat</header>
+<div class="flex flex-col w-full max-w-xl h-[90vh] bg-white rounded-lg shadow-lg">
+    <header class="bg-gradient-to-r from-blue-600 to-indigo-600 text-white p-4 text-center text-xl font-semibold">CivicAI Chat</header>
     <div id="chat" class="flex-1 overflow-y-auto p-4 space-y-2"></div>
     <form id="inputForm" class="flex border-t border-gray-200">
         <input type="text" id="message" placeholder="Type your message..." autocomplete="off" required class="flex-1 p-3 outline-none" />
-        <button type="submit" class="bg-blue-500 text-white px-4">Send</button>
+        <button type="submit" class="bg-blue-600 hover:bg-blue-700 text-white px-4">Send</button>
     </form>
 </div>
 <script>
@@ -22,33 +22,46 @@ const input = document.getElementById('message');
 
 function appendMessage(text, sender) {
     const div = document.createElement('div');
-    div.className = sender === 'You' ? 'self-end bg-blue-100 rounded-lg p-2 max-w-[80%]' : 'self-start bg-gray-100 rounded-lg p-2 max-w-[80%]';
+    div.className = sender === 'You'
+        ? 'self-end bg-blue-100 text-gray-900 rounded-lg p-2 max-w-[80%] shadow'
+        : 'self-start bg-gray-200 text-gray-900 rounded-lg p-2 max-w-[80%] shadow';
     div.textContent = text;
     div.classList.add('msg');
     chat.appendChild(div);
     chat.scrollTop = chat.scrollHeight;
 }
 
-function streamMessage(text) {
+async function streamMessage(text) {
     appendMessage('', 'Bot');
     const msgDiv = chat.lastChild;
-    fetch('/chat_stream', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ message: text })
-    }).then(resp => {
+    try {
+        const resp = await fetch('/chat_stream', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: text })
+        });
+        if (!resp.ok || !resp.body) throw new Error('stream unavailable');
         const reader = resp.body.getReader();
         const decoder = new TextDecoder();
-        function read() {
-            reader.read().then(({ done, value }) => {
-                if (done) return;
-                msgDiv.textContent += decoder.decode(value);
-                chat.scrollTop = chat.scrollHeight;
-                read();
-            });
+        while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            msgDiv.textContent += decoder.decode(value);
+            chat.scrollTop = chat.scrollHeight;
         }
-        read();
-    }).catch(err => { msgDiv.textContent = 'Error: ' + err; });
+    } catch (err) {
+        try {
+            const fallback = await fetch('/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ message: text })
+            });
+            const data = await fallback.json();
+            msgDiv.textContent = data.response;
+        } catch (err2) {
+            msgDiv.textContent = 'Error: ' + err2;
+        }
+    }
 }
 
 form.addEventListener('submit', e => {


### PR DESCRIPTION
## Summary
- style UI header and message bubbles
- add error handling with non-streaming fallback

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685db3f43278833296017ce637c6d91d