### PR TITLE
Add chat_stream docs

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -13,4 +13,5 @@ Available endpoints:
 
 - `GET /health` – verify the server is running.
 - `POST /chat` – interact with the language model.
+- `POST /chat_stream` – send `{"message": "<text>"}` and receive a plain-text stream of tokens. Unlike `/chat`, which returns a JSON object after generation finishes, this endpoint yields tokens as they are produced.
 - `POST /ingest` – rebuild the vector database.


### PR DESCRIPTION
## Summary
- document `/chat_stream` API endpoint

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dc2d99b808332b417647e6bb423c5