### PR TITLE
Add API_BASE prefix support for web chat

### DIFF
--- a/web/README.md
+++ b/web/README.md
@@ -17,5 +17,8 @@ python3 -m http.server 8080  # or `python -m http.server`
 Then open [http://localhost:8080](http://localhost:8080) in your browser and interact with the chat.
 
 Messages are sent to the `/chat` endpoint on the API server. When hosting the
-front end separately, ensure the FastAPI server is reachable and adjust the
-endpoint URL in `index.html` if needed.
+front end separately, ensure the FastAPI server is reachable. You can set a
+global `API_BASE` variable before loading `index.html` to prefix the endpoint
+URLs. For example, if the API is served under `/api`, define
+`window.API_BASE = '/api'` and the page will request `${API_BASE}/chat` and
+`${API_BASE}/chat_stream` automatically.

--- a/web/index.html
+++ b/web/index.html
@@ -19,6 +19,8 @@
 const chat = document.getElementById('chat');
 const form = document.getElementById('inputForm');
 const input = document.getElementById('message');
+// Allow customizing the API prefix via `window.API_BASE`
+const API_BASE = window.API_BASE || '';
 
 function appendMessage(text, sender) {
     const div = document.createElement('div');
@@ -35,7 +37,7 @@ async function streamMessage(text) {
     appendMessage('', 'Bot');
     const msgDiv = chat.lastChild;
     try {
-        const resp = await fetch('/chat_stream', {
+        const resp = await fetch(`${API_BASE}/chat_stream`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ message: text })
@@ -51,7 +53,7 @@ async function streamMessage(text) {
         }
     } catch (err) {
         try {
-            const fallback = await fetch('/chat', {
+            const fallback = await fetch(`${API_BASE}/chat`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ message: text })


### PR DESCRIPTION
## Summary
- allow setting `API_BASE` global to prefix API requests in the web UI
- update fetch calls in `index.html`
- document how to set `API_BASE` in the web README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dc2da9cf483329ec3cee79a42958f