### PR TITLE
Improve test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,13 +96,17 @@ API. Leaving this variable unset makes the app rely solely on the local
 
 ### Running tests
 
-Install the additional development packages before running the tests:
+Before running `pytest`, **you must install the development requirements**:
 
 ```bash
 pip install -r requirements-dev.txt
 ```
 
-Then execute the suite with `pytest`.
+After the dependencies are installed, run the suite with:
+
+```bash
+pytest
+```
 
 ### Running on Replit
 


### PR DESCRIPTION
## Summary
- clarify in README that development requirements must be installed before running tests

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement fastapi[test])* 
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685dc2db268c83328da51a39a1788b83