### PR TITLE
Fix langchain community dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,5 @@ chromadb==0.4.24
 openai==0.28.1
 ollama==0.1.4
 langchain_openai==0.1.3
-langchain_community==0.0.27
+# langchain==0.1.17 requires langchain-community>=0.0.36,<0.1
+langchain_community==0.0.36


### PR DESCRIPTION
## Summary
- bump `langchain_community` to a version compatible with `langchain==0.1.17`

## Testing
- `./setup.sh` *(fails: Could not fetch packages)*
- `pytest -q` *(fails: ModuleNotFoundError for fastapi)*

------
https://chatgpt.com/codex/tasks/task_e_685e06a40b3c8332805dc9fc46803dcd