### PR TITLE
Fix openai dependency conflict

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,8 @@ fastapi==0.111.0
 uvicorn==0.29.0
 langchain==0.1.17
 chromadb==0.4.24
-openai==0.28.1
+# openai>=1.10.0 is required by langchain-openai
+openai>=1.10.0,<2.0.0
 ollama==0.1.4
 langchain_openai==0.1.3
 # langchain==0.1.17 requires langchain-community>=0.0.36,<0.1


### PR DESCRIPTION
## Summary
- update `openai` requirement to meet `langchain-openai` constraints

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e09aa031083329ea57af9891a5398