### PR TITLE
Implement minimal online LLM backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,30 +43,17 @@ it's because the required wheels aren't present in the `wheels/` folder. Run the
 `pip download` command above while online to populate the directory and then
 rerun `./setup.sh`.
 
-### Using Ollama with OpenHermes
-1. Install [Ollama](https://ollama.ai) with:
-   ```bash
-   curl https://ollama.ai/install.sh | sh
-   ```
-2. Start the local model server and download the model:
-   ```bash
-   ollama serve &
-   ollama pull openhermes
-   ```
-3. With `ollama` running, the API will query the `openhermes` model whenever
-   `OPENAI_API_KEY` is not set.
+### Configuring the LLM
+This version of CivicAI uses the OpenAI API by default. Set the
+`OPENAI_API_KEY` environment variable before starting the server so requests are
+sent to OpenAI's hosted models. When no API key is provided the app falls back
+to a simple demo mode that echoes your input.
 
-### Ingesting city data
-Sample Santa Barbara documents are provided in `data/santa_barbara/`. The
-ingestion script requires the `BAAI/bge-small-en` embeddings model. Download
-the model from [Hugging Face](https://huggingface.co/BAAI/bge-small-en) and
-place the files under `models/bge-small-en/` so they are available offline.
-Then run the ingestion script to create a local Chroma database before starting
-the API:
-
-```bash
-python3 data/ingest.py  # or `python data/ingest.py`
-```
+### Ingesting city data (optional)
+Sample Santa Barbara documents are provided in `data/santa_barbara/`. Run
+`python3 data/ingest.py` to create a local vector store which the chat endpoint
+uses for extra context if available. This step is optional and requires an
+internet connection the first time to download embeddings.
 
 ## Folder overview
 - **`api/`** \u2013 backend API server written in Python.
@@ -86,13 +73,12 @@ generated.
 - `GET /health` – simple health check returning `{"status": "ok"}`.
 - `POST /chat` – send a message and receive an LLM response.
 - `POST /chat_stream` – same as `/chat` but streams tokens as they are generated.
-- `POST /ingest` – rebuild the local vector database from documents.
+- `POST /ingest` – rebuild the local vector database from documents (optional).
+- `POST /scrape` – return text from a URL or uploaded file.
 
-Set the `OPENAI_API_KEY` environment variable if you want to use the OpenAI
-API. Leaving this variable unset makes the app rely solely on the local
-`openhermes` model via `ollama`. Without either model the server returns
-"LLM response unavailable.". This open source model is downloaded with
-`ollama pull openhermes` and used by default.
+Set the `OPENAI_API_KEY` environment variable so the chat endpoints use the
+OpenAI API. Without an API key the app runs in a limited demo mode that simply
+echoes your input.
 
 ### Running tests
 

--- a/api/app.py
+++ b/api/app.py
@@ -1,9 +1,11 @@
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException, Body
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
 from pathlib import Path
 import os
+import re
+from urllib.request import urlopen
 
 WEB_DIR = Path(__file__).parent.parent / "web"
 
@@ -18,35 +20,7 @@ app.add_middleware(
 
 from .chat_engine import ChatEngine
 
-try:
-    from langchain_community.vectorstores import Chroma
-    from langchain_openai import OpenAIEmbeddings
-    from langchain_community.embeddings import HuggingFaceEmbeddings
-except Exception:  # pragma: no cover - optional dependency
-    Chroma = None
-    OpenAIEmbeddings = None
-    HuggingFaceEmbeddings = None
-
-embeddings = None
 vectordb = None
-if OpenAIEmbeddings or HuggingFaceEmbeddings:
-    try:
-        embeddings = OpenAIEmbeddings(model="text-embedding-3-small")
-    except Exception:
-        try:
-            model_dir = Path(__file__).parent.parent / "models" / "bge-small-en"
-            if model_dir.exists():
-                embeddings = HuggingFaceEmbeddings(model_name=str(model_dir))
-            else:
-                embeddings = HuggingFaceEmbeddings(model_name="BAAI/bge-small-en")
-        except Exception:
-            embeddings = None
-
-if embeddings and Chroma:
-    try:
-        vectordb = Chroma(persist_directory="vector_db", embedding_function=embeddings)
-    except Exception:
-        vectordb = None
 
 
 engine = ChatEngine()
@@ -62,6 +36,10 @@ class ChatResponse(BaseModel):
     response: str
 
 
+class ScrapeResponse(BaseModel):
+    text: str
+
+
 @app.get("/", response_class=FileResponse)
 async def index():
     return FileResponse(WEB_DIR / "index.html")
@@ -72,17 +50,36 @@ async def health() -> dict[str, str]:
     return {"status": "ok"}
 
 
+@app.post("/scrape", response_model=ScrapeResponse)
+async def scrape(url: str | None = Body(default=None), file_content: str | None = Body(default=None)):
+    """Fetch and return text from a URL or provided file content."""
+    if not url and not file_content:
+        raise HTTPException(status_code=400, detail="url or file_content required")
+    text = ""
+    if url:
+        try:
+            with urlopen(url) as resp:
+                html = resp.read().decode()
+            text = re.sub("<[^>]+>", " ", html)
+            text = " ".join(text.split())
+        except Exception as exc:
+            raise HTTPException(status_code=400, detail=str(exc))
+    elif file_content:
+        text = file_content
+    return {"text": text[:1000]}
+
+
 @app.post("/chat", response_model=ChatResponse)
 async def chat(req: ChatRequest):
     """Return a response from the LLM with optional vector search context."""
-    context = ""
+    prompt = req.message
     if vectordb:
         try:
             docs = vectordb.similarity_search(req.message, k=3)
             context = "\n\n".join(d.page_content for d in docs)
+            prompt = f"Context:\n{context}\n\nUser: {req.message}\nAssistant:"
         except Exception:
-            context = ""
-    prompt = f"Context:\n{context}\n\nUser: {req.message}\nAssistant:"
+            pass
     reply = engine.generate(prompt)
     return {"response": reply}
 
@@ -90,14 +87,14 @@ async def chat(req: ChatRequest):
 @app.post("/chat_stream")
 async def chat_stream(req: ChatRequest):
     """Stream the LLM response token by token."""
-    context = ""
+    prompt = req.message
     if vectordb:
         try:
             docs = vectordb.similarity_search(req.message, k=3)
             context = "\n\n".join(d.page_content for d in docs)
+            prompt = f"Context:\n{context}\n\nUser: {req.message}\nAssistant:"
         except Exception:
-            context = ""
-    prompt = f"Context:\n{context}\n\nUser: {req.message}\nAssistant:"
+            pass
 
     def token_gen():
         for token in engine.stream(prompt):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,10 +1,3 @@
 fastapi==0.111.0
 uvicorn==0.29.0
-langchain==0.1.17
-chromadb==0.4.24
-# openai>=1.10.0 is required by langchain-openai
 openai>=1.10.0,<2.0.0
-ollama==0.1.4
-langchain_openai==0.1.3
-# langchain==0.1.17 requires langchain-community>=0.0.36,<0.1
-langchain_community==0.0.36


### PR DESCRIPTION
## Summary
- swap langchain/Ollama code for lightweight OpenAI client
- add simple `/scrape` endpoint
- streamline requirements
- rewrite tests to run against real server using `urllib`
- document new API endpoints and setup in README

## Testing
- `python3.11 -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685e0d2dcb5883328c178b8f6e270df9