### PR TITLE
Fix scrape endpoint for Python 3.9

### DIFF
--- a/api/__init__.py
+++ b/api/__init__.py
@@ -1,0 +1,1 @@
+"""Make the api directory a package for test imports."""

--- a/api/app.py
+++ b/api/app.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI, HTTPException, Body
+from typing import Optional
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import FileResponse, StreamingResponse
 from pydantic import BaseModel
@@ -51,7 +52,7 @@ async def health() -> dict[str, str]:
 
 
 @app.post("/scrape", response_model=ScrapeResponse)
-async def scrape(url: str | None = Body(default=None), file_content: str | None = Body(default=None)):
+async def scrape(url: Optional[str] = Body(default=None), file_content: Optional[str] = Body(default=None)):
     """Fetch and return text from a URL or provided file content."""
     if not url and not file_content:
         raise HTTPException(status_code=400, detail="url or file_content required")


### PR DESCRIPTION
## Summary
- make `api` a package so tests can import it
- replace `str | None` union syntax with `Optional[str]` for Python 3.9 compatibility

## Testing
- `pip install -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement fastapi[test])* 
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685e15ca5ea88332b43c07ce8245b1b6