### PR TITLE
Change default port to 5000

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,5 +1,5 @@
 run = "bash start.sh"
 
 [[ports]]
-localPort = 8000
+localPort = 5000
 externalPort = 80

--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
 5. If you see `ModuleNotFoundError` errors (e.g., for FastAPI) or `pip` isn't found, rerun `./setup.sh` to ensure all dependencies are installed.
 6. Start the API server:
    ```bash
-   uvicorn main:app --host 0.0.0.0 --port 8000
+   uvicorn main:app --host 0.0.0.0 --port 5000
    ```
-7. Visit `http://localhost:8000/health` to confirm the server is running. The front-end UI is served automatically at `http://localhost:8000`.
+7. Visit `http://localhost:5000/health` to confirm the server is running. The front-end UI is served automatically at `http://localhost:5000`.
 
 Alternatively, execute `./start.sh` to perform steps 3–7 automatically.
 
@@ -66,7 +66,7 @@ internet connection the first time to download embeddings.
 Edit `api/app.py` to add endpoints or change logic. The server automatically reloads when you restart the command above. Front-end and data-related code live under `web/` and `data/` respectively.
 
 The included web interface (`web/index.html`) sends messages to the FastAPI
-server. When the API is running, open `http://localhost:8000/` to use the chat
+server. When the API is running, open `http://localhost:5000/` to use the chat
 UI. Responses stream back to the browser so you see the answer as it is
 generated.
 

--- a/api/README.md
+++ b/api/README.md
@@ -6,7 +6,7 @@ database can provide context:
 
 ```bash
 python3 ../data/ingest.py  # or `python ../data/ingest.py`
-uvicorn main:app --host 0.0.0.0 --port 8000
+uvicorn main:app --host 0.0.0.0 --port 5000
 ```
 
 Available endpoints:

--- a/api/app.py
+++ b/api/app.py
@@ -150,4 +150,4 @@ async def ingest_endpoint() -> dict[str, str]:
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=5000)

--- a/main.py
+++ b/main.py
@@ -27,4 +27,4 @@ except ModuleNotFoundError as exc:  # pragma: no cover - triggers only when deps
 if __name__ == "__main__":
     import uvicorn
 
-    uvicorn.run(app, host="0.0.0.0", port=8000)
+    uvicorn.run(app, host="0.0.0.0", port=5000)

--- a/start.sh
+++ b/start.sh
@@ -16,4 +16,4 @@ source .venv/bin/activate
 
 ./setup.sh
 
-.venv/bin/uvicorn main:app --host 0.0.0.0 --port 8000 --reload --log-level debug
+.venv/bin/uvicorn main:app --host 0.0.0.0 --port 5000 --reload --log-level debug

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -11,7 +11,7 @@ thread = None
 
 def setup_module(module):
     global server, thread
-    config = uvicorn.Config(app, host="127.0.0.1", port=8000, log_level="error")
+    config = uvicorn.Config(app, host="127.0.0.1", port=5000, log_level="error")
     server = uvicorn.Server(config)
     thread = threading.Thread(target=server.run, daemon=True)
     thread.start()
@@ -24,7 +24,7 @@ def teardown_module(module):
 
 
 def _post(path, payload=None):
-    url = f"http://127.0.0.1:8000{path}"
+    url = f"http://127.0.0.1:5000{path}"
     headers = {}
     data = None
     if payload is not None:
@@ -36,7 +36,7 @@ def _post(path, payload=None):
 
 
 def _get(path):
-    url = f"http://127.0.0.1:8000{path}"
+    url = f"http://127.0.0.1:5000{path}"
     with urllib.request.urlopen(url) as resp:
         return resp.read().decode()
 

--- a/web/README.md
+++ b/web/README.md
@@ -6,7 +6,7 @@ Press the **Send** button or hit **Enter** to submit a message. Use the **New Ch
 
 ## Launching the UI
 
-Once the API server is running, open [http://localhost:8000/](http://localhost:8000/) in your browser to chat.
+Once the API server is running, open [http://localhost:5000/](http://localhost:5000/) in your browser to chat.
 Any static file server can host the page as well. The simplest option is Python's built-in `http.server` module:
 
 ```bash


### PR DESCRIPTION
## Summary
- update documentation to use port 5000
- change uvicorn invocations to default to port 5000
- adjust test suite for new port
- update Replit config

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_685e1ef534b48332ac503efdface2ecc