### PR TITLE
Fix test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ pip install -r requirements-dev.txt
 After the dependencies are installed, run the suite with:
 
 ```bash
-pytest
+python -m pytest
 ```
 
 ### Running on Replit


### PR DESCRIPTION
## Summary
- point README test instructions to `python -m pytest`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ec21d56848332a9ea7d585de6e7d9