### PR TITLE
Ignore PyTest cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ env/
 vector_db/
 
 .DS_Store
+
+.pytest_cache/


### PR DESCRIPTION
## Summary
- ignore PyTest cache files in `.gitignore`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'api')*

------
https://chatgpt.com/codex/tasks/task_e_685ec21e467883329197364ac2e98fc3