### PR TITLE
Fix static serving and lint

### DIFF
--- a/api/chat_engine.py
+++ b/api/chat_engine.py
@@ -1,9 +1,8 @@
-from __future__ import annotations
-
 """Wrapper that attempts to use a real LLM via LangChain."""
 
+from __future__ import annotations
+
 from typing import Iterable
-import os
 import logging
 import time
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -72,7 +72,8 @@ def test_ingest_endpoint(monkeypatch):
     called = {}
     def fake_main():
         called["hit"] = True
-    import types, sys
+    import types
+    import sys
     dummy = types.SimpleNamespace(main=fake_main)
     monkeypatch.setitem(sys.modules, "data.ingest", dummy)
     data = json.loads(_post("/ingest"))


### PR DESCRIPTION
## Summary
- mount `web` directory using StaticFiles
- clean up imports and fix lint warnings
- split imports in ingest test

## Testing
- `ruff check api/app.py api/chat_engine.py tests/test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685ec55d552883329846deca06003fe7