### PR TITLE
Improve configurability of ingest and app

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,15 @@ Sample Santa Barbara documents are provided in `data/santa_barbara/`. Run
 uses for extra context if available. This step is optional and requires an
 internet connection the first time to download embeddings.
 
+### Configuration
+Two environment variables control where data is stored:
+
+- `VECTOR_DB_DIR` – location of the Chroma vector store (default `vector_db/`).
+- `DATA_DIR` – directory of text files to ingest (default `data/santa_barbara/`).
+
+Both the ingestion script and the API server honor these variables so you can
+customize paths without editing the code.
+
 ## Folder overview
 - **`api/`** \u2013 backend API server written in Python.
 - **`web/`** \u2013 front-end web application placeholder.

--- a/api/app.py
+++ b/api/app.py
@@ -41,7 +41,9 @@ async def index() -> FileResponse:
     return FileResponse(WEB_DIR / "index.html")
 
 logger.debug("Initializing ChatEngine and vector DB")
-DB_DIR = Path(__file__).parent.parent / "vector_db"
+# Allow overriding the vector store location via the VECTOR_DB_DIR environment variable
+db_env = os.getenv("VECTOR_DB_DIR")
+DB_DIR = Path(db_env) if db_env else Path(__file__).parent.parent / "vector_db"
 engine = ChatEngine()
 vectordb = None
 if DB_DIR.exists():

--- a/data/ingest.py
+++ b/data/ingest.py
@@ -1,6 +1,10 @@
 """Ingest Santa Barbara documents into a local Chroma vector store."""
 
+"""Ingest text documents into a local Chroma vector store."""
+
 from pathlib import Path
+import os
+import argparse
 
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 from langchain_community.vectorstores import Chroma
@@ -8,13 +12,13 @@ from langchain_openai import OpenAIEmbeddings
 from langchain_community.embeddings import HuggingFaceEmbeddings
 
 
-DATA_DIR = Path(__file__).parent / "santa_barbara"
-DB_DIR = Path(__file__).parent.parent / "vector_db"
+DEFAULT_DATA_DIR = Path(__file__).parent / "santa_barbara"
+DEFAULT_DB_DIR = Path(__file__).parent.parent / "vector_db"
 
 
-def load_documents() -> list[str]:
-    texts = []
-    for path in DATA_DIR.glob("*.txt"):
+def load_documents(data_dir: Path) -> list[str]:
+    texts: list[str] = []
+    for path in data_dir.glob("*.txt"):
         texts.append(path.read_text())
     return texts
 
@@ -29,20 +33,37 @@ def get_embeddings():
         return HuggingFaceEmbeddings(model_name="BAAI/bge-small-en")
 
 
-def main():
-    documents = load_documents()
+def ingest(data_dir: Path, db_dir: Path) -> None:
+    """Process ``data_dir`` and write embeddings to ``db_dir``."""
+    documents = load_documents(data_dir)
     splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)
     chunks = []
     for doc in documents:
         chunks.extend(splitter.split_text(doc))
 
     embeddings = get_embeddings()
-    vectordb = Chroma(persist_directory=str(DB_DIR), embedding_function=embeddings)
+    vectordb = Chroma(persist_directory=str(db_dir), embedding_function=embeddings)
     ids = [str(i) for i in range(len(chunks))]
     vectordb.add_texts(chunks, ids=ids)
     vectordb.persist()
-    print(f"Ingested {len(chunks)} chunks into {DB_DIR}")
+    print(f"Ingested {len(chunks)} chunks into {db_dir}")
+
+
+def main(data_dir: Path | None = None, db_dir: Path | None = None) -> None:
+    data_env = os.getenv("DATA_DIR")
+    db_env = os.getenv("VECTOR_DB_DIR")
+    data_dir = Path(data_env) if data_env else data_dir or DEFAULT_DATA_DIR
+    db_dir = Path(db_env) if db_env else db_dir or DEFAULT_DB_DIR
+    ingest(data_dir, db_dir)
+
+
+def _cli() -> None:
+    parser = argparse.ArgumentParser(description="Ingest documents into a Chroma vector store")
+    parser.add_argument("--data-dir", type=Path, help="Directory of text files", default=None)
+    parser.add_argument("--db-dir", type=Path, help="Destination for the vector DB", default=None)
+    args = parser.parse_args()
+    main(args.data_dir, args.db_dir)
 
 
 if __name__ == "__main__":
-    main()
+    _cli()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -79,3 +79,12 @@ def test_ingest_endpoint(monkeypatch):
     data = json.loads(_post("/ingest"))
     assert data == {"status": "completed"}
     assert called.get("hit") is True
+
+
+def test_env_overrides_vector_db(monkeypatch, tmp_path):
+    """The VECTOR_DB_DIR variable should control the DB location."""
+    monkeypatch.setenv("VECTOR_DB_DIR", str(tmp_path / "db"))
+    import importlib
+    import api.app as app_mod
+    importlib.reload(app_mod)
+    assert app_mod.DB_DIR == tmp_path / "db"


### PR DESCRIPTION
## Summary
- allow overriding vector DB directory via `VECTOR_DB_DIR`
- add optional `DATA_DIR` environment variable to `ingest.py`
- expose a small CLI for ingestion
- document new environment variables
- test that `VECTOR_DB_DIR` is respected

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686430754a5c8332a5a6a8a21d20be42