### PR TITLE
Improve configuration management and tests

### DIFF
--- a/api/chat_engine.py
+++ b/api/chat_engine.py
@@ -20,23 +20,26 @@ except Exception:  # pragma: no cover - optional dependency
 
 logger = logging.getLogger(__name__)
 
+
 class ChatEngine:
     """Handle chat completion requests."""
 
-    fallback_message = (
-        "The assistant is running in demo mode. Configure OPENAI_API_KEY for real answers."
-    )
+    fallback_message = "The assistant is running in demo mode. Configure OPENAI_API_KEY for real answers."
 
-    def __init__(self, model: str = "gpt-3.5-turbo", ollama_model: str = "llama2") -> None:
+    def __init__(
+        self,
+        model: str | None = None,
+        ollama_model: str | None = None,
+    ) -> None:
         """Initialize the engine and attempt to configure an LLM backend.
 
-        Model names can be overridden via the ``OPENAI_MODEL`` and
-        ``OLLAMA_MODEL`` environment variables.
+        ``model`` and ``ollama_model`` override the ``OPENAI_MODEL`` and
+        ``OLLAMA_MODEL`` environment variables when provided.
         """
         env_model = os.getenv("OPENAI_MODEL")
         env_ollama = os.getenv("OLLAMA_MODEL")
-        self.model = env_model or model
-        self.ollama_model = env_ollama or ollama_model
+        self.model = model or env_model or "gpt-3.5-turbo"
+        self.ollama_model = ollama_model or env_ollama or "llama2"
         self.llm = None
         self._init_llm()
 
@@ -73,7 +76,10 @@ class ChatEngine:
         else:
             try:
                 if hasattr(self.llm, "stream"):
-                    iterator = (getattr(chunk, "content", str(chunk)) for chunk in self.llm.stream(user_input))
+                    iterator = (
+                        getattr(chunk, "content", str(chunk))
+                        for chunk in self.llm.stream(user_input)
+                    )
                 else:
                     text = self.llm.invoke(user_input)
                     iterator = iter(str(text))

--- a/api/config.py
+++ b/api/config.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+from pydantic import BaseSettings
+
+
+class Settings(BaseSettings):
+    """Application configuration loaded from environment variables."""
+
+    vector_db_dir: Path = Path("vector_db")
+    data_dir: Path = Path("data/santa_barbara")
+    openai_model: str = "gpt-3.5-turbo"
+    ollama_model: str = "llama2"
+
+    class Config:
+        env_prefix = ""
+        case_sensitive = False
+
+
+settings = Settings()

--- a/data/ingest.py
+++ b/data/ingest.py
@@ -1,5 +1,3 @@
-"""Ingest Santa Barbara documents into a local Chroma vector store."""
-
 """Ingest text documents into a local Chroma vector store."""
 
 from pathlib import Path
@@ -58,9 +56,15 @@ def main(data_dir: Path | None = None, db_dir: Path | None = None) -> None:
 
 
 def _cli() -> None:
-    parser = argparse.ArgumentParser(description="Ingest documents into a Chroma vector store")
-    parser.add_argument("--data-dir", type=Path, help="Directory of text files", default=None)
-    parser.add_argument("--db-dir", type=Path, help="Destination for the vector DB", default=None)
+    parser = argparse.ArgumentParser(
+        description="Ingest documents into a Chroma vector store"
+    )
+    parser.add_argument(
+        "--data-dir", type=Path, help="Directory of text files", default=None
+    )
+    parser.add_argument(
+        "--db-dir", type=Path, help="Destination for the vector DB", default=None
+    )
     args = parser.parse_args()
     main(args.data_dir, args.db_dir)
 


### PR DESCRIPTION
## Summary
- centralize environment configuration in `api/config.py`
- initialize ChatEngine and Chroma DB on startup
- refresh vector DB when ingesting
- update ChatEngine to accept model overrides
- simplify API tests using `TestClient`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68643bdc11c48332aeb273d37c8ff2e0