### PR TITLE
Refactor startup lifecycle

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -8,6 +8,13 @@ import api.app as app_mod
 client = TestClient(app_mod.app)
 
 
+def test_create_app() -> None:
+    """create_app should return a new FastAPI instance each call."""
+    app1 = app_mod.create_app()
+    app2 = app_mod.create_app()
+    assert app1 is not app2
+
+
 def test_health():
     resp = client.get("/health")
     assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- expose `create_app` for testability
- manage the chat engine and vector DB using a FastAPI lifespan context
- access the state via `Request`
- add a unit test for `create_app`

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_68643f7cbc3c833290068418568d7281