### PR TITLE
Improve configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ Two environment variables control where data is stored:
 Both the ingestion script and the API server honor these variables so you can
 customize paths without editing the code.
 
+Additional optional variables:
+
+- `LOG_LEVEL` – Python logging level (default `INFO`).
+- `CORS_ORIGINS` – comma-separated list of allowed CORS origins (default `*`).
+
 ## Folder overview
 - **`api/`** \u2013 backend API server written in Python.
 - **`web/`** \u2013 front-end web application placeholder.

--- a/api/app.py
+++ b/api/app.py
@@ -57,11 +57,11 @@ async def lifespan(app: FastAPI):
 def create_app() -> FastAPI:
     """Return a fully configured FastAPI application."""
     app = FastAPI(lifespan=lifespan)
-    logging.basicConfig(level=logging.DEBUG)
+    logging.basicConfig(level=getattr(logging, settings.log_level.upper(), logging.INFO))
     logger = logging.getLogger(__name__)
     app.add_middleware(
         CORSMiddleware,
-        allow_origins=["*"],
+        allow_origins=settings.allowed_origins,
         allow_methods=["*"],
         allow_headers=["*"],
     )

--- a/api/config.py
+++ b/api/config.py
@@ -11,6 +11,13 @@ class Settings(BaseSettings):
     data_dir: Path = Path("data/santa_barbara")
     openai_model: str = "gpt-3.5-turbo"
     ollama_model: str = "llama2"
+    log_level: str = "INFO"
+    cors_origins: str = "*"
+
+    @property
+    def allowed_origins(self) -> list[str]:
+        """Return the CORS origins parsed from ``cors_origins``."""
+        return [o.strip() for o in self.cors_origins.split(",") if o.strip()]
 
     class Config:
         env_prefix = ""

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -82,6 +82,16 @@ def test_chat_engine_env_models(monkeypatch):
     assert engine.ollama_model == "bar"
 
 
+def test_settings_env(monkeypatch):
+    monkeypatch.setenv("LOG_LEVEL", "WARNING")
+    monkeypatch.setenv("CORS_ORIGINS", "https://a.com,https://b.com")
+    import api.config as cfg
+
+    importlib.reload(cfg)
+    assert cfg.settings.log_level == "WARNING"
+    assert cfg.settings.allowed_origins == ["https://a.com", "https://b.com"]
+
+
 def test_scrape_rejects_bad_scheme():
     resp = client.post("/scrape", json={"url": "file:///etc/passwd"})
     assert resp.status_code == 400


### PR DESCRIPTION
## Summary
- add configurable logging level and CORS origins
- document new environment variables
- test new settings parsing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_686440f945808332831a739350c87dca