### PR TITLE
Implement safer scraping with config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Additional optional variables:
 - `CORS_ORIGINS` – comma-separated list of allowed CORS origins (default `*`).
 - `HOST` – address the server binds to (default `0.0.0.0`).
 - `PORT` – port number for the API server (default `5000`).
+- `SCRAPE_TIMEOUT` – seconds to wait when fetching URLs (default `10`).
+- `SCRAPE_MAX_BYTES` – maximum characters returned by `/scrape` (default `100000`).
 
 ## Folder overview
 - **`api/`** \u2013 backend API server written in Python.

--- a/api/README.md
+++ b/api/README.md
@@ -15,3 +15,6 @@ Available endpoints:
 - `POST /chat` – interact with the language model.
 - `POST /chat_stream` – send `{"message": "<text>"}` and receive a plain-text stream of tokens. Unlike `/chat`, which returns a JSON object after generation finishes, this endpoint yields tokens as they are produced.
 - `POST /ingest` – rebuild the vector database.
+- `POST /scrape` – return sanitized text from a URL or uploaded file.
+
+Scrape behaviour can be configured using `SCRAPE_TIMEOUT` and `SCRAPE_MAX_BYTES` environment variables.

--- a/api/config.py
+++ b/api/config.py
@@ -15,6 +15,8 @@ class Settings(BaseSettings):
     cors_origins: str = "*"
     server_host: str = "0.0.0.0"
     server_port: int = 5000
+    scrape_timeout: float = 10.0
+    scrape_max_bytes: int = 100000
 
     @property
     def allowed_origins(self) -> list[str]:

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,0 +1,23 @@
+import ipaddress
+from urllib.parse import urlparse
+
+
+def is_public_url(url: str) -> bool:
+    """Return True if ``url`` points to a public host."""
+    host = urlparse(url).hostname
+    if not host:
+        return False
+    if host.lower() == "localhost":
+        return False
+    try:
+        ip = ipaddress.ip_address(host)
+        return not (
+            ip.is_private
+            or ip.is_loopback
+            or ip.is_reserved
+            or ip.is_link_local
+            or ip.is_multicast
+        )
+    except ValueError:
+        # Host isn't an IP address; assume it's valid
+        return True

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ ollama==0.1.4
 langchain_openai==0.1.3
 # langchain==0.1.17 requires langchain-community>=0.0.36,<0.1
 langchain_community==0.0.36
+httpx==0.27.0

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -99,3 +99,19 @@ def test_settings_env(monkeypatch):
 def test_scrape_rejects_bad_scheme():
     resp = client.post("/scrape", json={"url": "file:///etc/passwd"})
     assert resp.status_code == 400
+
+
+def test_scrape_rejects_private_ip():
+    resp = client.post("/scrape", json={"url": "http://127.0.0.1"})
+    assert resp.status_code == 400
+
+
+def test_scrape_settings_env(monkeypatch):
+    monkeypatch.setenv("SCRAPE_TIMEOUT", "5.5")
+    monkeypatch.setenv("SCRAPE_MAX_BYTES", "123")
+    import importlib
+    import api.config as cfg
+
+    importlib.reload(cfg)
+    assert cfg.settings.scrape_timeout == 5.5
+    assert cfg.settings.scrape_max_bytes == 123


### PR DESCRIPTION
## Summary
- secure the `/scrape` endpoint by refusing private URLs
- fetch URLs asynchronously with `httpx`
- add `SCRAPE_TIMEOUT` and `SCRAPE_MAX_BYTES` settings
- document new settings and endpoint
- test new configuration options

## Testing
- `python -m pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6864461e18b88332bfc4caeb8966812e