### PR TITLE
Improve logging and ingestion

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,9 +71,10 @@ Two environment variables control where data is stored:
 Both the ingestion script and the API server honor these variables so you can
 customize paths without editing the code.
 
-Additional optional variables:
+-Additional optional variables:
 
-- `LOG_LEVEL` – Python logging level (default `INFO`).
+- `LOG_LEVEL` – Python logging level (default `INFO`). The server
+  configures logging automatically using this level.
 - `CORS_ORIGINS` – comma-separated list of allowed CORS origins (default `*`).
 - `HOST` – address the server binds to (default `0.0.0.0`).
 - `PORT` – port number for the API server (default `5000`).

--- a/api/app.py
+++ b/api/app.py
@@ -12,6 +12,8 @@ import re
 from urllib.parse import urlparse
 import httpx
 import logging
+
+from .logging_utils import setup_logging
 import queue
 import threading
 from .chat_engine import ChatEngine
@@ -20,6 +22,9 @@ from langchain_openai import OpenAIEmbeddings
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_community.vectorstores import Chroma
 from .config import settings
+
+setup_logging(settings.log_level)
+logger = logging.getLogger(__name__)
 
 WEB_DIR = Path(__file__).parent.parent / "web"
 
@@ -72,8 +77,6 @@ async def lifespan(app: FastAPI):
 def create_app() -> FastAPI:
     """Return a fully configured FastAPI application."""
     app = FastAPI(lifespan=lifespan)
-    logging.basicConfig(level=getattr(logging, settings.log_level.upper(), logging.INFO))
-    logger = logging.getLogger(__name__)
     app.add_middleware(
         CORSMiddleware,
         allow_origins=settings.allowed_origins,
@@ -92,7 +95,6 @@ def create_app() -> FastAPI:
 
 
 app = create_app()
-logger = logging.getLogger(__name__)
 
 
 class ChatRequest(BaseModel):

--- a/api/logging_utils.py
+++ b/api/logging_utils.py
@@ -1,0 +1,23 @@
+"""Utilities for configuring application logging."""
+
+from __future__ import annotations
+
+import logging
+
+
+def setup_logging(level: str) -> None:
+    """Configure Python logging.
+
+    Parameters
+    ----------
+    level:
+        Logging verbosity name such as ``"INFO"`` or ``"DEBUG"``.
+    """
+    numeric = getattr(logging, level.upper(), logging.INFO)
+    logging.basicConfig(
+        level=numeric,
+        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+        force=True,
+    )
+
+

--- a/data/ingest.py
+++ b/data/ingest.py
@@ -18,9 +18,10 @@ logger = logging.getLogger(__name__)
 
 
 def load_documents(data_dir: Path) -> list[str]:
+    """Return the UTF-8 contents of ``data_dir`` text files."""
     texts: list[str] = []
     for path in data_dir.glob("*.txt"):
-        texts.append(path.read_text())
+        texts.append(path.read_text(encoding="utf-8"))
     return texts
 
 
@@ -36,6 +37,11 @@ def get_embeddings():
 
 def ingest(data_dir: Path, db_dir: Path) -> None:
     """Process ``data_dir`` and write embeddings to ``db_dir``."""
+    data_dir = data_dir.expanduser()
+    db_dir = db_dir.expanduser()
+    if not data_dir.exists():
+        raise FileNotFoundError(f"{data_dir} does not exist")
+
     logger.info("Ingesting documents from %s", data_dir)
     documents = load_documents(data_dir)
     splitter = RecursiveCharacterTextSplitter(chunk_size=500, chunk_overlap=50)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -143,3 +143,12 @@ def test_build_prompt_with_vectordb():
 
     prompt = build_prompt("hello", DummyDB())
     assert "context1" in prompt and "User: hello" in prompt
+
+def test_setup_logging_sets_level(monkeypatch):
+    import logging
+    from importlib import reload
+    import api.logging_utils as lu
+
+    reload(lu)
+    lu.setup_logging("DEBUG")
+    assert logging.getLogger().getEffectiveLevel() == logging.DEBUG


### PR DESCRIPTION
## Summary
- document auto logging configuration
- set up logging via new `api.logging_utils` module
- make ingestion more robust
- test logging helper

## Testing
- `pytest -q` *(fails: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866a8ebf54c8332b8efdef2088e9fc5