### PR TITLE
Add .env configuration support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Copy this file to .env and adjust values as needed
+VECTOR_DB_DIR=vector_db
+DATA_DIR=data/santa_barbara
+OPENAI_MODEL=gpt-3.5-turbo
+OLLAMA_MODEL=llama2
+LOG_LEVEL=INFO
+CORS_ORIGINS=*
+HOST=0.0.0.0
+PORT=5000
+SCRAPE_TIMEOUT=10.0
+SCRAPE_MAX_BYTES=100000
+FALLBACK_MESSAGE=The assistant is running in demo mode. Configure OPENAI_API_KEY for real answers.
+# OPENAI_API_KEY=your-api-key

--- a/README.md
+++ b/README.md
@@ -9,12 +9,13 @@ CivicAI is a self-hosted AI chatbot that answers local government questions\u201
    `python3 -m venv .venv && source .venv/bin/activate` (use `python -m venv` if `python3` isn't available).
    If no environment is active, `./setup.sh` automatically creates `.venv` and installs packages there.
 4. Install dependencies using `./setup.sh`. When the `wheels/` directory contains wheel files the script installs from them; otherwise it falls back to downloading packages. This script also installs `pip` when it's missing and activates `.venv` when necessary.
-5. If you see `ModuleNotFoundError` errors (e.g., for FastAPI) or `pip` isn't found, rerun `./setup.sh` to ensure all dependencies are installed.
-6. Start the API server (customize the host and port with `HOST` and `PORT`):
+5. Copy `.env.example` to `.env` and adjust the settings if desired. The application automatically loads this file on startup.
+6. If you see `ModuleNotFoundError` errors (e.g., for FastAPI) or `pip` isn't found, rerun `./setup.sh` to ensure all dependencies are installed.
+7. Start the API server (customize the host and port with `HOST` and `PORT`):
    ```bash
    HOST=0.0.0.0 PORT=5000 uvicorn main:app --host "$HOST" --port "$PORT"
    ```
-7. Visit `http://<host>:<port>/health` to confirm the server is running. The front-end UI is served automatically at `http://<host>:<port>`.
+8. Visit `http://<host>:<port>/health` to confirm the server is running. The front-end UI is served automatically at `http://<host>:<port>`.
 
 Alternatively, execute `./start.sh` to perform steps 3–7 automatically.
 
@@ -81,6 +82,11 @@ customize paths without editing the code.
 - `SCRAPE_TIMEOUT` – seconds to wait when fetching URLs (default `10`).
 - `SCRAPE_MAX_BYTES` – maximum characters returned by `/scrape` (default `100000`).
 - `FALLBACK_MESSAGE` – text returned when no language model is available.
+
+All of these settings can be placed in a `.env` file in the project root. The
+server automatically loads this file on startup, so you can keep your
+environment variables out of shell scripts. See `.env.example` for a sample
+configuration.
 
 ## Folder overview
 - **`api/`** \u2013 backend API server written in Python.

--- a/api/config.py
+++ b/api/config.py
@@ -29,6 +29,7 @@ class Settings(BaseSettings):
     class Config:
         env_prefix = ""
         case_sensitive = False
+        env_file = ".env"
 
 
 settings = Settings()

--- a/main.py
+++ b/main.py
@@ -4,24 +4,10 @@ try:
     from api.app import app
 except ModuleNotFoundError as exc:  # pragma: no cover - triggers only when deps missing
     if exc.name == "fastapi":
-        import subprocess
-        from pathlib import Path
-
-        script = Path(__file__).with_name("setup.sh")
-        if script.exists():
-            try:
-                subprocess.run(["bash", str(script)], check=True)
-                from api.app import app  # retry after installing deps
-            except Exception:
-                raise SystemExit(
-                    "FastAPI is not installed. Run './setup.sh' to install all dependencies."
-                ) from exc
-        else:
-            raise SystemExit(
-                "FastAPI is not installed. Run './setup.sh' to install all dependencies."
-            ) from exc
-    else:
-        raise
+        raise SystemExit(
+            "FastAPI is not installed. Run './setup.sh' to install required dependencies."
+        ) from exc
+    raise
 
 
 if __name__ == "__main__":

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -152,3 +152,14 @@ def test_setup_logging_sets_level(monkeypatch):
     reload(lu)
     lu.setup_logging("DEBUG")
     assert logging.getLogger().getEffectiveLevel() == logging.DEBUG
+
+
+def test_env_file(monkeypatch, tmp_path):
+    env = tmp_path / ".env"
+    env.write_text("PORT=4321\n")
+    monkeypatch.chdir(tmp_path)
+    import importlib
+    import api.config as cfg
+
+    importlib.reload(cfg)
+    assert cfg.settings.server_port == 4321


### PR DESCRIPTION
## Summary
- support loading environment settings from `.env`
- remove automatic dependency installation in `main.py`
- document environment configuration in README
- provide `.env.example`
- test `.env` support

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866aa7e52648332ba55839d85ab9c8d