### PR TITLE
Improve ingestion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ generated.
 - `GET /health` – simple health check returning `{"status": "ok"}`.
 - `POST /chat` – send a message and receive an LLM response.
 - `POST /chat_stream` – same as `/chat` but streams tokens as they are generated.
-- `POST /ingest` – rebuild the local vector database from documents (optional).
-- `POST /scrape` – return text from a URL or uploaded file.
+ - `POST /ingest` – rebuild the local vector database from documents (optional). The server performs ingestion in a background thread so the API remains responsive.
+ - `POST /scrape` – return text from a URL or uploaded file.
 
 Set `OPENAI_API_KEY` to send requests to OpenAI's hosted models. When the
 variable is unset the server looks for an Ollama instance instead. If neither is

--- a/api/app.py
+++ b/api/app.py
@@ -237,12 +237,14 @@ async def chat_stream(req: ChatRequest, request: Request):
 
 @app.post("/ingest")
 async def ingest_endpoint(request: Request) -> dict[str, str]:
-    """Trigger data ingestion to rebuild the vector database."""
+    """Trigger data ingestion without blocking the event loop."""
     logger.debug("POST /ingest called")
     try:
         from data.ingest import main as ingest_main
 
-        ingest_main(settings.data_dir, settings.vector_db_dir)
+        await asyncio.to_thread(
+            ingest_main, settings.data_dir, settings.vector_db_dir
+        )
         request.app.state.vectordb = load_vectordb(settings.vector_db_dir)
         return {"status": "completed"}
     except Exception as exc:


### PR DESCRIPTION
## Summary
- run ingestion in a background thread so the event loop stays responsive
- document non-blocking ingestion in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866b87158c48332a3bf7eec1ab83a72