### PR TITLE
Enable async LLM calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ configuration.
 - **`data/`** \u2013 example datasets and loading scripts.
 
 ## Development
-Edit `api/app.py` to add endpoints or change logic. The server automatically reloads when you restart the command above. Front-end and data-related code live under `web/` and `data/` respectively.
+Edit `api/app.py` to add endpoints or change logic. The server automatically reloads when you restart the command above. Front-end and data-related code live under `web/` and `data/` respectively.  
+The chat endpoints now leverage asynchronous LLM calls when possible so responses stream back efficiently.
 
 The included web interface (`web/index.html`) sends messages to the FastAPI
 server. When the API is running, open `http://localhost:5000/` to use the chat

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -194,3 +194,23 @@ def test_chat_engine_demo_mode(monkeypatch):
     importlib.reload(ce)
     engine = ce.ChatEngine()
     assert engine.demo_mode is True
+
+
+@pytest.mark.asyncio
+async def test_chat_engine_generate_async():
+    from api.chat_engine import ChatEngine
+
+    engine = ChatEngine()
+    text = await engine.generate_async("hi", timeout=1.0)
+    assert text
+
+
+@pytest.mark.asyncio
+async def test_chat_engine_stream_async():
+    from api.chat_engine import ChatEngine
+
+    engine = ChatEngine()
+    parts = []
+    async for chunk in engine.stream_async("hi", timeout=1.0):
+        parts.append(chunk)
+    assert "".join(parts)


### PR DESCRIPTION
## Summary
- support async generation/streaming in `ChatEngine`
- simplify API handlers to use the async methods
- document async behaviour in README
- test new async helpers

## Testing
- `python -m py_compile api/chat_engine.py api/app.py`
- `python -m py_compile tests/test_api.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866ba2349ec8332b50ee88fe33cbdd6