### PR TITLE
Improve scrape sanitization and utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,9 @@ generated.
 - `GET /health` – simple health check returning `{"status": "ok"}`.
 - `POST /chat` – send a message and receive an LLM response.
 - `POST /chat_stream` – same as `/chat` but streams tokens as they are generated.
- - `POST /ingest` – rebuild the local vector database from documents (optional). The server performs ingestion in a background thread so the API remains responsive.
- - `POST /scrape` – return text from a URL or uploaded file.
+- `POST /ingest` – rebuild the local vector database from documents (optional). The server performs ingestion in a background thread so the API remains responsive.
+ - `POST /scrape` – return text from a URL or uploaded file. HTML content is
+   sanitized so only plain text is returned.
 
 Set `OPENAI_API_KEY` to send requests to OpenAI's hosted models. When the
 variable is unset the server looks for an Ollama instance instead. If neither is

--- a/api/app.py
+++ b/api/app.py
@@ -10,13 +10,12 @@ from fastapi.staticfiles import StaticFiles
 from fastapi.responses import FileResponse
 from pydantic import BaseModel, ValidationError, model_validator, HttpUrl
 from pathlib import Path
-import re
 import httpx
 import logging
 
 from .logging_utils import setup_logging
 from .chat_engine import ChatEngine
-from .utils import is_public_url
+from .utils import is_public_url, html_to_text
 from langchain_openai import OpenAIEmbeddings
 from langchain_community.embeddings import HuggingFaceEmbeddings
 from langchain_community.vectorstores import Chroma
@@ -169,8 +168,7 @@ async def scrape(payload: ScrapeRequest):
                         if size >= limit:
                             break
                     html = "".join(parts)[:limit]
-            text = re.sub("<[^>]+>", " ", html)
-            text = " ".join(text.split())
+            text = html_to_text(html)
         elif payload.file_content:
             text = payload.file_content.strip()
         return {"text": text[:limit]}

--- a/api/utils.py
+++ b/api/utils.py
@@ -1,5 +1,12 @@
+"""Utility helpers for the API server."""
+
+from __future__ import annotations
+
 import ipaddress
 from urllib.parse import urlparse
+from html.parser import HTMLParser
+
+__all__ = ["is_public_url", "html_to_text"]
 
 
 def is_public_url(url: str) -> bool:
@@ -21,3 +28,25 @@ def is_public_url(url: str) -> bool:
     except ValueError:
         # Host isn't an IP address; assume it's valid
         return True
+
+
+class _TextExtractor(HTMLParser):
+    """Internal HTML parser that collects text fragments."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.parts: list[str] = []
+
+    def handle_data(self, data: str) -> None:  # pragma: no cover - trivial
+        self.parts.append(data)
+
+    def text(self) -> str:
+        return " ".join(" ".join(self.parts).split())
+
+
+def html_to_text(html: str) -> str:
+    """Return ``html`` with tags stripped and whitespace normalized."""
+    parser = _TextExtractor()
+    parser.feed(html)
+    return parser.text()
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -40,6 +40,13 @@ def test_scrape_file():
     assert "Alice" in data["text"]
 
 
+def test_scrape_html_sanitization():
+    html = "<html><body><h1>Hello</h1><p>World</p></body></html>"
+    resp = client.post("/scrape", json={"file_content": html})
+    assert resp.status_code == 200
+    assert resp.json()["text"] == "Hello World"
+
+
 def test_scrape_requires_data():
     """scrape should reject requests without url or file_content."""
     resp = client.post("/scrape", json={})
@@ -214,3 +221,10 @@ async def test_chat_engine_stream_async():
     async for chunk in engine.stream_async("hi", timeout=1.0):
         parts.append(chunk)
     assert "".join(parts)
+
+
+def test_html_to_text():
+    from api.utils import html_to_text
+
+    text = html_to_text("<div>Hello <b>world</b></div>")
+    assert text == "Hello world"


### PR DESCRIPTION
## Summary
- sanitize scraped HTML using a small parser
- expose `html_to_text` utility and unit tests
- note sanitization in the README

## Testing
- `ruff check api tests`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866bf66970c8332ae948d431fb3c7dc