### PR TITLE
Improve scraping utilities

### DIFF
--- a/api/utils.py
+++ b/api/utils.py
@@ -31,14 +31,24 @@ def is_public_url(url: str) -> bool:
 
 
 class _TextExtractor(HTMLParser):
-    """Internal HTML parser that collects text fragments."""
+    """Internal HTML parser that collects text while skipping script/style tags."""
 
     def __init__(self) -> None:
         super().__init__()
         self.parts: list[str] = []
+        self._skip: bool = False
+
+    def handle_starttag(self, tag: str, _attrs) -> None:  # pragma: no cover - trivial
+        if tag in {"script", "style"}:
+            self._skip = True
+
+    def handle_endtag(self, tag: str) -> None:  # pragma: no cover - trivial
+        if tag in {"script", "style"}:
+            self._skip = False
 
     def handle_data(self, data: str) -> None:  # pragma: no cover - trivial
-        self.parts.append(data)
+        if not self._skip:
+            self.parts.append(data)
 
     def text(self) -> str:
         return " ".join(" ".join(self.parts).split())

--- a/data/ingest.py
+++ b/data/ingest.py
@@ -18,14 +18,15 @@ logger = logging.getLogger(__name__)
 
 
 def load_documents(data_dir: Path) -> list[str]:
-    """Return the UTF-8 contents of ``data_dir`` text files."""
+    """Return the UTF-8 contents of all ``*.txt`` files sorted by name."""
     texts: list[str] = []
-    for path in data_dir.glob("*.txt"):
+    for path in sorted(data_dir.glob("*.txt")):
         texts.append(path.read_text(encoding="utf-8"))
     return texts
 
 
 def get_embeddings():
+    """Return an embeddings backend, preferring OpenAI when available."""
     try:
         return OpenAIEmbeddings(model="text-embedding-3-small")
     except Exception:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -230,6 +230,13 @@ def test_html_to_text():
     assert text == "Hello world"
 
 
+def test_html_to_text_strips_script_style():
+    from api.utils import html_to_text
+
+    html = "<div>Good</div><script>bad()</script><style>.x{}</style>Bye"
+    assert html_to_text(html) == "Good Bye"
+
+
 def test_settings_port_validation(monkeypatch):
     monkeypatch.setenv("PORT", "70000")
     import importlib


### PR DESCRIPTION
## Summary
- ignore script/style tags when converting HTML to text
- guarantee deterministic document ingestion order
- verify script/style removal in `html_to_text` tests

## Testing
- `pip install -r requirements-dev.txt` *(fails: Tunnel connection failed)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_6866c4a4808c8332b136f6bd08b19619